### PR TITLE
DMPlex Exodus: minor cleanup and fix a previous commit

### DIFF
--- a/MEF90/m_MEF90_DMPlex.F90
+++ b/MEF90/m_MEF90_DMPlex.F90
@@ -382,22 +382,22 @@ Contains
 !!!  (c) 2022      Alexis Marboeuf marboeua@mcmaster.ca
 !!!
 
-subroutine MEF90_VecReorderingSF(vin,vout,sf,ierr)
-    Type(tVec),intent(IN)              :: vin
-    Type(tVec),intent(INOUT)           :: vout
-    Type(tPetscSF),intent(IN)          :: sf
-    PetscErrorCode,intent(INOUT)       :: ierr
+    Subroutine MEF90_VecReorderingSF(vin,vout,sf,ierr)
+        Type(tVec),intent(IN)              :: vin
+        Type(tVec),intent(INOUT)           :: vout
+        Type(tPetscSF),intent(IN)          :: sf
+        PetscErrorCode,intent(INOUT)       :: ierr
 
-    PetscScalar,dimension(:),Pointer   :: arrayin, arrayout
+        PetscScalar,dimension(:),Pointer   :: arrayin, arrayout
 
-    PetscCallA(VecGetArrayReadF90(vin, arrayin, ierr))
-    PetscCallA(VecGetArrayF90(vout, arrayout, ierr))
-    PetscCallA(PetscSFBcastBegin(sf, MPIU_SCALAR, arrayin, arrayout, MPI_REPLACE, ierr))
-    PetscCallA(PetscSFBcastEnd(sf, MPIU_SCALAR, arrayin, arrayout, MPI_REPLACE, ierr))
-    PetscCallA(VecRestoreArrayReadF90(vin, arrayin, ierr))
-    PetscCallA(VecRestoreArrayF90(vout, arrayout, ierr))
-    
-End subroutine MEF90_VecReorderingSF
+        PetscCallA(VecGetArrayReadF90(vin, arrayin, ierr))
+        PetscCallA(VecGetArrayF90(vout, arrayout, ierr))
+        PetscCallA(PetscSFBcastBegin(sf, MPIU_SCALAR, arrayin, arrayout, MPI_REPLACE, ierr))
+        PetscCallA(PetscSFBcastEnd(sf, MPIU_SCALAR, arrayin, arrayout, MPI_REPLACE, ierr))
+        PetscCallA(VecRestoreArrayReadF90(vin, arrayin, ierr))
+        PetscCallA(VecRestoreArrayF90(vout, arrayout, ierr))
+        
+    End subroutine MEF90_VecReorderingSF
 
 #undef __FUNCT__
 #define __FUNCT__ "MEF90_CreateLocalToIOSF"
@@ -408,31 +408,31 @@ End subroutine MEF90_VecReorderingSF
 !!!  (c) 2022      Alexis Marboeuf marboeua@mcmaster.ca
 !!!
 
-subroutine MEF90_CreateLocalToIOSF(MEF90Ctx,dm,sf,ierr)
-    Type(tDM),intent(IN)               :: dm
-    Type(tPetscSF),intent(OUT)         :: sf
-    Type(MEF90Ctx_type),Intent(IN)     :: MEF90Ctx
-    PetscErrorCode,intent(INOUT)       :: ierr
+    Subroutine MEF90_CreateLocalToIOSF(MEF90Ctx,dm,sf,ierr)
+        Type(tDM),intent(IN)               :: dm
+        Type(tPetscSF),intent(OUT)         :: sf
+        Type(MEF90Ctx_type),Intent(IN)     :: MEF90Ctx
+        PetscErrorCode,intent(INOUT)       :: ierr
 
-    Type(tPetscSF)                     :: naturalSF, ioSF, lcgSF, tempSF
+        Type(tPetscSF)                     :: naturalSF, ioSF, lcgSF, tempSF
 
-    PetscCallA(CreateLocalToCGlobalSF(MEF90Ctx,dm,lcgSF,ierr))
-    If (MEF90Ctx%NumProcs > 1) Then
-        PetscCallA(CreateNaturalToIOSF(MEF90Ctx,dm,ioSF,ierr))
-        PetscCallA(DMGetNaturalSF(dm,naturalSF,ierr))
-        PetscCallA(PetscSFCompose(lcgSF,naturalSF,tempSF,ierr))
-        PetscCallA(PetscSFCompose(tempSF,ioSF,sf,ierr))
-        PetscCallA(PetscSFDestroy(lcgSF,ierr))
-        PetscCallA(PetscSFDestroy(ioSF,ierr))
-        PetscCallA(PetscSFDestroy(tempSF,ierr))
-        PetscCallA(PetscSFSetUp(sf,ierr))
-    Else
-        sf = lcgSF
-    End If
-    PetscCallA(PetscObjectSetName(sf, "Local-To-IO SF", ierr))
-    PetscCallA(PetscSFViewFromOptions(sf,PETSC_NULL_OPTIONS,"-localtoio_sf_view",ierr))
-    
-End subroutine MEF90_CreateLocalToIOSF
+        PetscCallA(CreateLocalToCGlobalSF(MEF90Ctx,dm,lcgSF,ierr))
+        If (MEF90Ctx%NumProcs > 1) Then
+            PetscCallA(CreateNaturalToIOSF(MEF90Ctx,dm,ioSF,ierr))
+            PetscCallA(DMGetNaturalSF(dm,naturalSF,ierr))
+            PetscCallA(PetscSFCompose(lcgSF,naturalSF,tempSF,ierr))
+            PetscCallA(PetscSFCompose(tempSF,ioSF,sf,ierr))
+            PetscCallA(PetscSFDestroy(lcgSF,ierr))
+            PetscCallA(PetscSFDestroy(ioSF,ierr))
+            PetscCallA(PetscSFDestroy(tempSF,ierr))
+            PetscCallA(PetscSFSetUp(sf,ierr))
+        Else
+            sf = lcgSF
+        End If
+        PetscCallA(PetscObjectSetName(sf, "Local-To-IO SF", ierr))
+        PetscCallA(PetscSFViewFromOptions(sf,PETSC_NULL_OPTIONS,"-localtoio_sf_view",ierr))
+        
+    End subroutine MEF90_CreateLocalToIOSF
 
 #undef __FUNCT__
 #define __FUNCT__ "MEF90_CreateIOToLocalSF"
@@ -443,33 +443,33 @@ End subroutine MEF90_CreateLocalToIOSF
 !!!  (c) 2022      Alexis Marboeuf marboeua@mcmaster.ca
 !!!
 
-subroutine MEF90_CreateIOToLocalSF(MEF90Ctx,dm,sf,ierr)
-    Type(tDM),intent(IN)               :: dm
-    Type(tPetscSF),intent(OUT)         :: sf
-    Type(MEF90Ctx_type),Intent(IN)     :: MEF90Ctx
-    PetscErrorCode,intent(INOUT)       :: ierr
+    Subroutine MEF90_CreateIOToLocalSF(MEF90Ctx,dm,sf,ierr)
+        Type(tDM),intent(IN)               :: dm
+        Type(tPetscSF),intent(OUT)         :: sf
+        Type(MEF90Ctx_type),Intent(IN)     :: MEF90Ctx
+        PetscErrorCode,intent(INOUT)       :: ierr
 
-    Type(tPetscSF)                     :: naturalSF, ioSF, cglSF, tempSF, invTempSF
+        Type(tPetscSF)                     :: naturalSF, ioSF, cglSF, tempSF, invTempSF
 
-    PetscCallA(CreateCGlobalToLocalSF(MEF90Ctx,dm,cglSF,ierr))
-    If (MEF90Ctx%NumProcs > 1) Then
-        PetscCallA(CreateNaturalToIOSF(MEF90Ctx,dm,ioSF,ierr))
-        PetscCallA(DMGetNaturalSF(dm,naturalSF,ierr))
-        PetscCallA(PetscSFCompose(naturalSF,ioSF,tempSF,ierr))
-        PetscCallA(PetscSFCreateInverseSF(tempSF,invTempSF,ierr))
-        PetscCallA(PetscSFCompose(invTempSF,cglSF,sf,ierr))
-        PetscCallA(PetscSFDestroy(ioSF,ierr))
-        PetscCallA(PetscSFDestroy(cglSF,ierr))
-        PetscCallA(PetscSFDestroy(tempSF,ierr))
-        PetscCallA(PetscSFDestroy(invTempSF,ierr))
-        PetscCallA(PetscSFSetUp(sf,ierr))
-    Else
-        sf = cglSF
-    End If
-    PetscCallA(PetscObjectSetName(sf, "IO-To-Local SF", ierr))
-    PetscCallA(PetscSFViewFromOptions(sf,PETSC_NULL_OPTIONS,"-iotolocal_sf_view",ierr))
-    
-End subroutine MEF90_CreateIOToLocalSF
+        PetscCallA(CreateCGlobalToLocalSF(MEF90Ctx,dm,cglSF,ierr))
+        If (MEF90Ctx%NumProcs > 1) Then
+            PetscCallA(CreateNaturalToIOSF(MEF90Ctx,dm,ioSF,ierr))
+            PetscCallA(DMGetNaturalSF(dm,naturalSF,ierr))
+            PetscCallA(PetscSFCompose(naturalSF,ioSF,tempSF,ierr))
+            PetscCallA(PetscSFCreateInverseSF(tempSF,invTempSF,ierr))
+            PetscCallA(PetscSFCompose(invTempSF,cglSF,sf,ierr))
+            PetscCallA(PetscSFDestroy(ioSF,ierr))
+            PetscCallA(PetscSFDestroy(cglSF,ierr))
+            PetscCallA(PetscSFDestroy(tempSF,ierr))
+            PetscCallA(PetscSFDestroy(invTempSF,ierr))
+            PetscCallA(PetscSFSetUp(sf,ierr))
+        Else
+            sf = cglSF
+        End If
+        PetscCallA(PetscObjectSetName(sf, "IO-To-Local SF", ierr))
+        PetscCallA(PetscSFViewFromOptions(sf,PETSC_NULL_OPTIONS,"-iotolocal_sf_view",ierr))
+        
+    End subroutine MEF90_CreateIOToLocalSF
 
 #undef __FUNCT__
 #define __FUNCT__ "MEF90_CreateLocalToConstraintSF"
@@ -481,60 +481,96 @@ End subroutine MEF90_CreateIOToLocalSF
 !!!                Blaise Bourdin  bourdin@mcmaster.ca
 !!!
 
-subroutine MEF90_CreateLocalToConstraintSF(MEF90Ctx,dm,dmB,sf,invSF,ierr)
-    Type(tDM),intent(IN)                    :: dm, dmB
-    Type(tPetscSF),intent(OUT)              :: sf, invSF
-    Type(MEF90Ctx_type),Intent(IN)          :: MEF90Ctx
-    PetscErrorCode,intent(INOUT)            :: ierr
+    Subroutine MEF90_CreateLocalToConstraintSF(MEF90Ctx,dm,dmB,sf,invSF,ierr)
+        Type(tDM),intent(IN)                    :: dm, dmB
+        Type(tPetscSF),intent(OUT)              :: sf, invSF
+        Type(MEF90Ctx_type),Intent(IN)          :: MEF90Ctx
+        PetscErrorCode,intent(INOUT)            :: ierr
 
-    Type(tPetscSection)                     :: locSection, locBSection
-    Type(PetscSFNode),dimension(:),Pointer  :: remote
-    Type(PetscInt),dimension(:),Pointer     :: local, cindices
-    PetscInt                                :: pStart, pEnd, p, d, nleaves = 0, ldof, loff, cdof, coff, nsize = 0, nroots
-    PetscMPIInt                             :: rank
+        Type(tPetscSection)                     :: locSection, locBSection
+        Type(PetscSFNode),dimension(:),Pointer  :: remote
+        Type(PetscInt),dimension(:),Pointer     :: local, cindices
+        PetscInt                                :: pStart, pEnd, p, d, nleaves = 0, ldof, loff, cdof, coff, nsize = 0, nroots
+        PetscMPIInt                             :: rank
 
-    nleaves = 0
-    nsize   = 0
-    PetscCallMPI(MPI_Comm_rank(MEF90Ctx%Comm, rank, ierr))
-    PetscCall(DMGetLocalSection(dm,locSection,ierr))
-    PetscCall(PetscSectionGetStorageSize(locSection,nroots,ierr))
-    PetscCall(DMGetLocalSection(dmB,locBSection,ierr))
-    PetscCall(PetscSectionGetChart(locBSection, pStart, pEnd, ierr))
-    Do p = pStart,pEnd-1
-        PetscCall(PetscSectionGetConstraintDof(locBSection,p,cdof,ierr))
-        nleaves = nleaves + cdof
-    End Do
-    Allocate(remote(nleaves))
-    Allocate(local(nleaves))
-    Do p = pStart,pEnd-1
-        PetscCall(PetscSectionGetDoF(locSection,p,ldof,ierr))
-        PetscCall(PetscSectionGetOffset(locSection,p,loff,ierr))
-        PetscCall(PetscSectionGetConstraintDof(locBSection,p,cdof,ierr))
-        If (cdof > 0) then
-            PetscCall(PetscSectionGetConstraintIndicesF90(locBSection,p,cindices,ierr))
-            PetscCall(PetscSectionGetOffset(locBSection,p,coff,ierr))
-            If (coff >= 0) Then
-                Do d=1,cdof
-                    local(nsize+1) = coff+cindices(d)
-                    remote(nsize+1)%rank = rank
-                    remote(nsize+1)%index = loff+cindices(d)
-                    nsize = nsize + 1
-                End Do
-            End If
-            PetscCall(PetscSectionRestoreConstraintIndicesF90(locBSection,p,cindices,ierr))
-        End If ! cdof
-    End Do
-    PetscCall(PetscSFCreate(MEF90Ctx%Comm, sf, ierr))
-    PetscCall(PetscSFSetFromOptions(sf, ierr))
-    PetscCall(PetscSFSetGraph(sf, nroots, nleaves, local, PETSC_COPY_VALUES, remote, PETSC_COPY_VALUES, ierr))
-    DeAllocate(remote)
-    DeAllocate(local)
-    PetscCall(PetscSFSetUp(sf, ierr))
-    PetscCall(PetscObjectSetName(sf, "Local-To-Constraint SF", ierr))
-    !PetscCall(PetscSFViewFromOptions(sf,PETSC_NULL_OPTIONS,"-localtoconstraint_sf_view",ierr))
-    PetscCall(PetscSFCreateInverseSF(sf,invSF,ierr))
-    PetscCall(PetscSFSetUp(invSF, ierr))
-    PetscCall(PetscObjectSetName(invSF, "Constraint-To-Local SF", ierr))
-    !PetscCall(PetscSFViewFromOptions(invSF,PETSC_NULL_OPTIONS,"-constrainttolocal_sf_view",ierr))   
-End Subroutine MEF90_CreateLocalToConstraintSF
+        nleaves = 0
+        nsize   = 0
+        PetscCallMPI(MPI_Comm_rank(MEF90Ctx%Comm, rank, ierr))
+        PetscCall(DMGetLocalSection(dm,locSection,ierr))
+        PetscCall(PetscSectionGetStorageSize(locSection,nroots,ierr))
+        PetscCall(DMGetLocalSection(dmB,locBSection,ierr))
+        PetscCall(PetscSectionGetChart(locBSection, pStart, pEnd, ierr))
+        Do p = pStart,pEnd-1
+            PetscCall(PetscSectionGetConstraintDof(locBSection,p,cdof,ierr))
+            nleaves = nleaves + cdof
+        End Do
+        Allocate(remote(nleaves))
+        Allocate(local(nleaves))
+        Do p = pStart,pEnd-1
+            PetscCall(PetscSectionGetDoF(locSection,p,ldof,ierr))
+            PetscCall(PetscSectionGetOffset(locSection,p,loff,ierr))
+            PetscCall(PetscSectionGetConstraintDof(locBSection,p,cdof,ierr))
+            If (cdof > 0) then
+                PetscCall(PetscSectionGetConstraintIndicesF90(locBSection,p,cindices,ierr))
+                PetscCall(PetscSectionGetOffset(locBSection,p,coff,ierr))
+                If (coff >= 0) Then
+                    Do d=1,cdof
+                        local(nsize+1) = coff+cindices(d)
+                        remote(nsize+1)%rank = rank
+                        remote(nsize+1)%index = loff+cindices(d)
+                        nsize = nsize + 1
+                    End Do
+                End If
+                PetscCall(PetscSectionRestoreConstraintIndicesF90(locBSection,p,cindices,ierr))
+            End If ! cdof
+        End Do
+        PetscCall(PetscSFCreate(MEF90Ctx%Comm, sf, ierr))
+        PetscCall(PetscSFSetFromOptions(sf, ierr))
+        PetscCall(PetscSFSetGraph(sf, nroots, nleaves, local, PETSC_COPY_VALUES, remote, PETSC_COPY_VALUES, ierr))
+        DeAllocate(remote)
+        DeAllocate(local)
+        PetscCall(PetscSFSetUp(sf, ierr))
+        PetscCall(PetscObjectSetName(sf, "Local-To-Constraint SF", ierr))
+        !PetscCall(PetscSFViewFromOptions(sf,PETSC_NULL_OPTIONS,"-localtoconstraint_sf_view",ierr))
+        PetscCall(PetscSFCreateInverseSF(sf,invSF,ierr))
+        PetscCall(PetscSFSetUp(invSF, ierr))
+        PetscCall(PetscObjectSetName(invSF, "Constraint-To-Local SF", ierr))
+        !PetscCall(PetscSFViewFromOptions(invSF,PETSC_NULL_OPTIONS,"-constrainttolocal_sf_view",ierr))   
+    End Subroutine MEF90_CreateLocalToConstraintSF
+
+#undef __FUNCT__
+#define __FUNCT__ "MEF90_CreateLocalMEF90_VecGlobalToLocalConstraintToConstraintSF"
+!!!
+!!!  
+!!!  MEF90_VecGlobalToLocalConstraint: do a VecGlobaltoLocal then copy constrained values
+!!!  
+!!!  (c) 2022      Blaise Bourdin  bourdin@mcmaster.ca
+!!!
+
+    Subroutine MEF90_VecGlobalToLocalConstraint(g,c,l,ierr)
+        Type(tVec),Intent(IN)                   :: g,c
+        Type(tVec),Intent(INOUT)                :: l
+        PetscErrorCode,Intent(INOUT)            :: ierr
+
+        Type(tDM)                               :: dm
+        Type(tPetscSection)                     :: s
+        PetscInt                                :: numConstraint
+        PetscInt                                :: p,pStart,pEnd
+        PetscReal,Dimension(:),Pointer          :: vArray
+
+        PetscCall(VecGetDM(g,dm,ierr))
+        PetscCall(DMGlobalToLocal(dm,g,INSERT_VALUES,l,ierr))
+        If (c /= PETSC_NULL_VEC) Then
+            PetscCall(DMGetLocalSection(dm,s,ierr))
+            PetscCallA(PetscSectionGetChart(s,pStart,pEnd,ierr))
+            Do p = pStart,pEnd-1
+                PetscCall(PetscSectionGetConstraintDof(s,p,numConstraint,ierr))
+                If (numConstraint > 0) Then
+                    PetscCallA(VecGetValuesSectionF90(c,s,p,vArray,ierr))
+                    PetscCallA(VecSetValuesSectionF90(l,s,p,vArray,INSERT_ALL_VALUES,ierr))
+                    PetscCallA(VecRestoreValuesSectionF90(c,s,p,vArray,ierr))
+                End If ! numConstraint
+            End Do ! p
+        End If
+    End Subroutine MEF90_VecGlobalToLocalConstraint
 End Module m_MEF90_DMPlex

--- a/MEF90/m_MEF90_EXO.F90
+++ b/MEF90/m_MEF90_EXO.F90
@@ -16,8 +16,8 @@ Subroutine MEF90EXOGetVarIndex(exoid,obj_type,name,varIndex,ierr)
    Integer,Intent(OUT)              :: varIndex
    PetscErrorCode,Intent(OUT)       :: ierr
 
-   Integer                          :: i, j, num_suffix = 5, num_vars
-   Character(len=MXSTLN)            :: ext_name, var_name, suffix(5)
+   Integer                          :: num_vars
+   Character(len=MXSTLN)            :: suffix(5)
 
    suffix(1:5) = ["   ","_X ","_XX","_1 ","_11"]
    
@@ -481,23 +481,12 @@ Contains
       Type(tPetscViewer),Intent(IN)                      :: Viewer
       PetscErrorCode,Intent(OUT)                         :: ierr
 
-      PetscInt                                           :: exoid, offsetN, offsetZ
-      Character(len=PETSC_MAX_PATH_LEN)                  :: vecname, IOBuffer
+      PetscInt                                           :: exoid, offsetN
+      Character(len=PETSC_MAX_PATH_LEN)                  :: vecname
 
       PetscCallA(PetscViewerExodusIIGetId(Viewer,exoid,ierr))
       PetscCallA(PetscObjectGetName(v, vecname,ierr))
 
       PetscCallA(MEF90EXOGetVarIndex(exoid,EX_NODAL,vecname,offsetN,ierr))
-      !PetscCallA(MEF90EXOGetVarIndex_Internal(exoid,EX_ELEM_BLOCK,vecname,offsetZ,ierr))
-      !write(*,*) "OffsetN = ",OffsetN," OffsetZ = ",OffsetZ
-      !PetscCheck(offsetN > 0 || offsetZ > 0,comm, PETSC_ERR_FILE_UNEXPECTED, "Found both nodal and zonal variable %s in exodus file. ", vecname)
-      !If (offsetN > 0) Then
-         !PetscCallA(VecViewPlex_ExodusII_Nodal_Internal(v,exoid,step+1,offsetN))
-      !Else If (offsetZ > 0) Then
-         !PetscCall(VecViewPlex_ExodusII_Zonal_Internal(v,exoid,(int) step+1,offsetZ));
-      !Else
-         !write(IOBuffer,'("Could not find nodal or zonal variable ", I2, " in exodus file. ")') vecname
-         !SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_FILE_UNEXPECTED,IOBuffer)
-      !End If
    End Subroutine MEF90EXOVecView
 End Module m_MEF90_EXO


### PR DESCRIPTION
Minor cleanup in MEF90/m_MEF90_DMPlex.F90 and MEF90/m_MEF90_EXO.F90.
Add the removed subroutine MEF90_VecGlobalToLocalConstraint erased from
a previous commit.