### PR TITLE
Speed up compilation with explicit only-lists on module imports

### DIFF
--- a/HeatXfer/HeatXfer.F90
+++ b/HeatXfer/HeatXfer.F90
@@ -4,7 +4,9 @@ Program HeatXfer
    Use m_MEF90
    Use m_MEF90_HeatXfer
    Use m_MEF90_HeatXferDefault
-   implicit none (type, external)   
+   Use m_MEF90_EXO, only: MEF90CtxOpenEXO, MEF90EXODMView, MEF90EXOFormat
+   Use m_MEF90_Utils, only: MEF90ISAllGatherMerge
+   implicit none (type, external)
 
    PetscErrorCode                                     :: ierr
    Type(MEF90Ctx_Type),target                         :: MEF90Ctx

--- a/HeatXfer/Makefile
+++ b/HeatXfer/Makefile
@@ -1,6 +1,6 @@
 NP=2
 all:
-	-@${MAKE} -C ${MEF90_DIR} HeatXfer
+	@${MAKE} -C ${MEF90_DIR} HeatXfer
 test: test2D test3D testTransient2D testTransient3D
 test1:
 	-@for OPTIONSFILE in test1.yaml; do \
@@ -42,15 +42,15 @@ HeatXfer:${MEF90_DIR}/${PETSC_ARCH}/bin/HeatXfer
 
 ${MEF90_DIR}/${PETSC_ARCH}/bin/HeatXfer: HeatXfer.o
 	-@echo "      $@"
-	-@${FLINKER} -o $@ HeatXfer.o m_HeatXferDefault.o ${MEF90_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} 
+	@${FLINKER} -o $@ HeatXfer.o m_HeatXferDefault.o ${MEF90_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} 
 
 HeatXfer.o: ${BASE_DIR}/HeatXfer.F90 ${MEF90_HEATXFER_OBJS} m_HeatXferDefault.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_HeatXferDefault.o: ${BASE_DIR}/m_HeatXferDefault.F90 ${MEF90_HEATXFER_OBJS}
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 testHeatXfer:
 	@echo ;echo "Testing HeatXfer with $${PREFIX} $${OPTIONSFILE}"

--- a/HeatXfer/m_HeatXferDefault.F90
+++ b/HeatXfer/m_HeatXferDefault.F90
@@ -1,7 +1,9 @@
 Module m_MEF90_HeatXferDefault
 #include <petsc/finclude/petsc.h>
+    Use m_MEF90
+    Use m_MEF90_HeatXferCtx
     Use m_MEF90_HeatXfer
-    implicit none (type, external)   
+    implicit none (type, external)
 
     Type(MEF90CtxGlobalOptions_Type),Parameter         :: MEF90DefaultGlobalOptions = MEF90CtxGlobalOptions_Type( &
                                                             1,                               & ! verbose

--- a/MEF90/Makefile
+++ b/MEF90/Makefile
@@ -1,5 +1,5 @@
 all:
-	-@${MAKE} -C ${MEF90_DIR} MEF90
+	@${MAKE} -C ${MEF90_DIR} MEF90
 
 include ${PETSC_DIR}/lib/petsc/conf/variables
 include ${PETSC_DIR}/lib/petsc/conf/rules
@@ -34,29 +34,29 @@ m_MEF90.o: ${MEF90_DIR}/MEF90/m_MEF90.F90 \
         m_MEF90_NormsInterface.o \
         m_MEF90_BaseClass.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_BaseClass.o: ${MEF90_DIR}/MEF90/m_MEF90_BaseClass.F90 \
         m_MEF90_Parameters.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_Ctx.o: ${MEF90_DIR}/MEF90/m_MEF90_Ctx.F90 \
         m_MEF90_Parameters.o m_MEF90_Utils.o m_MEF90_Elements.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DMPlex.o: ${MEF90_DIR}/MEF90/m_MEF90_DMPlex.F90 \
         m_MEF90_Elements.o m_MEF90_Ctx.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_Elements.o: ${MEF90_DIR}/MEF90/m_MEF90_Elements.F90 \
         m_MEF90_LinAlg.o \
         m_MEF90_Parameters.o \
         m_MEF90_Utils.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_EXO.o: ${MEF90_DIR}/MEF90/m_MEF90_EXO.F90 m_MEF90_Ctx.o \
         m_MEF90_DMPlex.o \
@@ -64,13 +64,13 @@ m_MEF90_EXO.o: ${MEF90_DIR}/MEF90/m_MEF90_EXO.F90 m_MEF90_Ctx.o \
         m_MEF90_Parameters.o \
         m_MEF90_Utils.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_LinAlg.o: ${MEF90_DIR}/MEF90/m_MEF90_LinAlg.F90 \
         m_MEF90_Parameters.o \
         m_MEF90_Utils.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_HookesLawClass.o: ${MEF90_DIR}/MEF90/m_MEF90_HookesLawClass.F90 \
         m_MEF90_Parameters.o \
@@ -78,12 +78,12 @@ m_MEF90_HookesLawClass.o: ${MEF90_DIR}/MEF90/m_MEF90_HookesLawClass.F90 \
         m_MEF90_BaseClass.o \
         m_MEF90_Utils.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_HookesLawIsotropic.o: ${MEF90_DIR}/MEF90/m_MEF90_HookesLawIsotropic.F90 \
         m_MEF90_HookesLawClass.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 # m_MEF90_HookesLawZero.o: ${MEF90_DIR}/MEF90/m_MEF90_HookesLawZero.F90 \
 #         m_MEF90_HookesLawClass.o
@@ -93,7 +93,7 @@ m_MEF90_HookesLawIsotropic.o: ${MEF90_DIR}/MEF90/m_MEF90_HookesLawIsotropic.F90 
 m_MEF90_HookesLaw.o: ${MEF90_DIR}/MEF90/m_MEF90_HookesLaw.F90 \
         m_MEF90_HookesLawIsotropic.o #m_MEF90_HookesLawZero.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 ###
 ### MassMatrix for each element type
@@ -104,28 +104,28 @@ m_MEF90_MassMatrixImplementation_MEF90Element2D_Scal.o: ${MEF90_DIR}/MEF90/m_MEF
         m_MEF90_Utils.o \
         m_MEF90_DMPlex.o
 	@echo "      $< MEF90Element2DScal"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element2DScal -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element2DScal -c -o $@ $<
 m_MEF90_MassMatrixImplementation_MEF90Element2D_Vect.o: ${MEF90_DIR}/MEF90/m_MEF90_MassMatrixImplementation.F90 \
         m_MEF90_Elements.o \
         m_MEF90_Parameters.o \
         m_MEF90_Utils.o \
         m_MEF90_DMPlex.o
 	@echo "      $< MEF90Element2DVect"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element2DVect -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element2DVect -c -o $@ $<
 m_MEF90_MassMatrixImplementation_MEF90Element3D_Scal.o: ${MEF90_DIR}/MEF90/m_MEF90_MassMatrixImplementation.F90 \
         m_MEF90_Elements.o \
         m_MEF90_Parameters.o \
         m_MEF90_Utils.o \
         m_MEF90_DMPlex.o
 	@echo "      $< MEF90Element3DScal"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element3DScal -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element3DScal -c -o $@ $<
 m_MEF90_MassMatrixImplementation_MEF90Element3D_Vect.o: ${MEF90_DIR}/MEF90/m_MEF90_MassMatrixImplementation.F90 \
         m_MEF90_Elements.o \
         m_MEF90_Parameters.o \
         m_MEF90_Utils.o \
         m_MEF90_DMPlex.o
 	@echo "      $< MEF90Element3DVect"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element3DVect -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element3DVect -c -o $@ $<
 
 m_MEF90_MassMatrixInterface.o: ${MEF90_DIR}/MEF90/m_MEF90_MassMatrixInterface.F90 m_MEF90_LinAlg.o \
         m_MEF90_MassMatrixImplementation_MEF90Element2D_Scal.o \
@@ -134,7 +134,7 @@ m_MEF90_MassMatrixInterface.o: ${MEF90_DIR}/MEF90/m_MEF90_MassMatrixInterface.F9
         m_MEF90_MassMatrixImplementation_MEF90Element3D_Vect.o \
         m_MEF90_Parameters.o m_MEF90_Utils.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 ###
 ### Norms for each element type
@@ -145,7 +145,7 @@ m_MEF90_NormsImplementation_MEF90Element2D_Scal.o: ${MEF90_DIR}/MEF90/m_MEF90_No
         m_MEF90_Utils.o \
         m_MEF90_DMPlex.o
 	@echo "      $< MEF90Element2DScal"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element2DScal -DMEF90_ELEMENTTYPE_SCALAR -DMEF90_DIM=2 -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element2DScal -DMEF90_ELEMENTTYPE_SCALAR -DMEF90_DIM=2 -c -o $@ $<
 
 m_MEF90_NormsImplementation_MEF90Element2D_Vect.o: ${MEF90_DIR}/MEF90/m_MEF90_NormsImplementation.F90 \
         m_MEF90_Elements.o \
@@ -153,14 +153,14 @@ m_MEF90_NormsImplementation_MEF90Element2D_Vect.o: ${MEF90_DIR}/MEF90/m_MEF90_No
         m_MEF90_Utils.o \
         m_MEF90_DMPlex.o
 	@echo "      $< MEF90Element2DVect"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element2DVect -DMEF90_ELEMENTTYPE_VECT  -DMEF90_DIM=2 -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element2DVect -DMEF90_ELEMENTTYPE_VECT  -DMEF90_DIM=2 -c -o $@ $<
 m_MEF90_NormsImplementation_MEF90Element3D_Scal.o: ${MEF90_DIR}/MEF90/m_MEF90_NormsImplementation.F90 \
         m_MEF90_Elements.o \
         m_MEF90_Parameters.o \
         m_MEF90_Utils.o \
         m_MEF90_DMPlex.o
 	@echo "      $< MEF90Element3DScal"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element3DScal -DMEF90_ELEMENTTYPE_SCALAR -DMEF90_DIM=3 -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element3DScal -DMEF90_ELEMENTTYPE_SCALAR -DMEF90_DIM=3 -c -o $@ $<
 
 m_MEF90_NormsImplementation_MEF90Element3D_Vect.o: ${MEF90_DIR}/MEF90/m_MEF90_NormsImplementation.F90 \
         m_MEF90_Elements.o \
@@ -168,7 +168,7 @@ m_MEF90_NormsImplementation_MEF90Element3D_Vect.o: ${MEF90_DIR}/MEF90/m_MEF90_No
         m_MEF90_Utils.o \
         m_MEF90_DMPlex.o
 	@echo "      $< MEF90Element3DVect"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element3DVect -DMEF90_ELEMENTTYPE_VECT  -DMEF90_DIM=3 -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_ELEMENTTYPE=MEF90Element3DVect -DMEF90_ELEMENTTYPE_VECT  -DMEF90_DIM=3 -c -o $@ $<
 
 m_MEF90_NormsInterface.o: ${MEF90_DIR}/MEF90/m_MEF90_NormsInterface.F90 m_MEF90_LinAlg.o \
         m_MEF90_NormsImplementation_MEF90Element2D_Scal.o \
@@ -177,7 +177,7 @@ m_MEF90_NormsInterface.o: ${MEF90_DIR}/MEF90/m_MEF90_NormsInterface.F90 m_MEF90_
         m_MEF90_NormsImplementation_MEF90Element3D_Vect.o \
         m_MEF90_Parameters.o m_MEF90_Utils.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_Materials.o: ${MEF90_DIR}/MEF90/m_MEF90_Materials.F90 \
         m_MEF90_Ctx.o \
@@ -186,20 +186,20 @@ m_MEF90_Materials.o: ${MEF90_DIR}/MEF90/m_MEF90_Materials.F90 \
         m_MEF90_Parameters.o \
         m_MEF90_Utils.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_MPI.o: ${MEF90_DIR}/MEF90/m_MEF90_MPI.F90 \
         m_MEF90_Parameters.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_Parameters.o: ${MEF90_DIR}/MEF90/m_MEF90_Parameters.F90
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_Utils.o: ${MEF90_DIR}/MEF90/m_MEF90_Utils.F90 \
         m_MEF90_MPI.o \
         m_MEF90_Parameters.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 

--- a/MEF90/m_MEF90.F90
+++ b/MEF90/m_MEF90.F90
@@ -1,21 +1,17 @@
 module m_MEF90
 #include "petsc/finclude/petsc.h"
 #include "../mef90version.h"
-   use m_MEF90_Ctx
+   use petscsys
+   use m_MEF90_Ctx, only: MEF90CtxInitialize_Private
    use m_MEF90_LinAlg
    use m_MEF90_Parameters
-   use m_MEF90_baseClass
-   use m_MEF90_Materials
-   use m_MEF90_MPI
-   use m_MEF90_EXO
-   use m_MEF90_Utils
-   use m_MEF90_DMPlex
-   use m_MEF90_Elements
-   use m_MEF90_MassMatrixInterface
-   use m_MEF90_NormsInterface
-   use m_MEF90_HookesLaw
+   use m_MEF90_Materials, only: MEF90MaterialsInitialize_Private
+   use m_MEF90_MPI, only: MEF90MPIInitialize_Private, MEF90MPIFinalize_Private
+   use m_MEF90_Elements, only: MEF90ElementsInitialize_Private
 
    implicit none(type, external)
+   private
+   public :: MEF90Initialize, MEF90Finalize
 
 contains
 #undef __FUNCT__

--- a/MEF90/m_MEF90_Ctx.F90
+++ b/MEF90/m_MEF90_Ctx.F90
@@ -1,12 +1,12 @@
 module m_MEF90_Ctx_Type
 #include "petsc/finclude/petsc.h"
+   use petscsys
    use petscbag
    use m_MEF90_Parameters
-   use m_MEF90_Utils
    use m_MEF90_LinAlg
-   use m_MEF90_Elements
    use, intrinsic :: iso_c_binding
    implicit none(type, external)
+
    private
    public :: MEF90Ctx_Type
    public :: MEF90CtxGlobalOptions_Type
@@ -36,21 +36,33 @@ end module m_MEF90_Ctx_Type
 module m_MEF90_Ctx
 #include "petsc/finclude/petsc.h"
    use, intrinsic :: iso_c_binding
+   use petscsys
    use petscbag
    use m_MEF90_Parameters
-   use m_MEF90_Utils
+   use m_MEF90_Utils, only: MEF90FilePrefix, MEF90FileExtension, MEF90StrTokenize
    use m_MEF90_LinAlg
-   use m_MEF90_Elements
-   use m_MEF90_Ctx_Type
+   use m_MEF90_Elements, only: MEF90ElementFamilyList, MEF90ElementFamilyLagrange
+   use m_MEF90_Ctx_Type, only: MEF90Ctx_Type, MEF90CtxGlobalOptions_Type
 
    implicit none(type)
+   private
+#include "exodusII.inc"
 
    public :: MEF90Ctx_Type
    public :: MEF90CtxGlobalOptions_Type
+   public :: MEF90CtxCreate
+   public :: MEF90CtxDestroy
    public :: MEF90CtxInitialize_Private
    public :: PetscBagGetDataMEF90CtxGlobalOptions
    public :: MEF90CtxGetTime
    public :: sizeofMEF90CtxGlobalOptions
+   public :: MEF90Scaling_CST, MEF90Scaling_Linear, MEF90Scaling_File, MEF90Scaling_Expr, MEF90Scaling_Null
+   public :: MEF90ScalingList
+   public :: MEF90TimeInterpolation_linear, MEF90TimeInterpolation_Vcycle
+   public :: MEF90TimeInterpolation_quadratic, MEF90TimeInterpolation_exo
+   public :: MEF90TimeInterpolationList
+   public :: MEF90ElementFamilyLagrange
+   public :: MEF90ElementFamilyList
 
    PetscSizeT, protected    :: sizeofMEF90CtxGlobalOptions
 

--- a/MEF90/m_MEF90_DMPlex.F90
+++ b/MEF90/m_MEF90_DMPlex.F90
@@ -1,11 +1,13 @@
 module m_MEF90_DMPlex
 #include "petsc/finclude/petsc.h"
 #include "petsc/finclude/petscsf.h"
+   use petscdmplex
    use m_MEF90_Parameters
-   use m_MEF90_Utils
+   use m_MEF90_Utils, only: MEF90ISAllGatherMerge, MEF90StrTokenize, MEF90StrCount
    use m_MEF90_LinAlg
-   use m_MEF90_Elements
-   use m_MEF90_Ctx
+   use m_MEF90_Elements, only: MEF90ElementType, MEF90ElementGetType, MEF90ElementGetTypeBoundary, &
+      MEF90P0Lagrange2D, MEF90P0Lagrange3D, MEF90P0Lagrange2DBoundary, MEF90P0Lagrange3DBoundary
+   use m_MEF90_Ctx, only: MEF90Ctx_Type
    use, intrinsic :: iso_c_binding
 #ifdef MEF90_HAVE_SYMENGINEF90
    use symengine

--- a/MEF90/m_MEF90_EXO.F90
+++ b/MEF90/m_MEF90_EXO.F90
@@ -1,15 +1,17 @@
 module m_MEF90_EXO
 #include "petsc/finclude/petsc.h"
+   use petscsys
+   use petscdmplex
+   use, intrinsic :: iso_c_binding
    use m_MEF90_Parameters
-   use m_MEF90_Utils
-   use m_MEF90_Elements
-   use m_MEF90_Ctx
-   use m_MEF90_DMPlex
+   use m_MEF90_Ctx, only: MEF90Ctx_Type
+   use m_MEF90_DMPlex, only: MEF90VecCreateIO, MEF90VecCopySF
 
    implicit none(type)
 #include "../mef90version.h"
 
    private
+#include "exodusII.inc"
    PetscInt, public                                 :: exo_ver
 
    public :: MEF90CtxOpenEXO

--- a/MEF90/m_MEF90_Elements.F90
+++ b/MEF90/m_MEF90_Elements.F90
@@ -1,13 +1,12 @@
 module m_MEF90_Elements
 #include "petsc/finclude/petsc.h"
    use m_MEF90_Parameters
-   use m_MEF90_Utils
    use m_MEF90_LinAlg
    use petscdmplex
    use, intrinsic :: iso_c_binding
    implicit none(type, external)
 
-   !Private
+   private
    public :: MEF90ElementCreate
    public :: MEF90ElementDestroy
 
@@ -15,6 +14,9 @@ module m_MEF90_Elements
    public :: MEF90Element2DVect, MEF90Element2DScal
    public :: MEF90Element3DVect, MEF90Element3DScal
    public :: MEF90ElementGetType, MEF90ElementGetTypeBoundary
+   public :: MEF90ElementFamilyLagrange
+   public :: MEF90ElementFamilyList
+   public :: MEF90ElementsInitialize_Private
 
    type MEF90ElementType
       ! name is the element name in english language

--- a/MEF90/m_MEF90_HookesLaw.F90
+++ b/MEF90/m_MEF90_HookesLaw.F90
@@ -2,10 +2,9 @@
 module m_MEF90_HookesLaw
 #include "petsc/finclude/petsc.h"
    use m_MEF90_Parameters
-   use m_MEF90_Utils
-   use m_MEF90_HookesLaw_class
-   use m_MEF90_HookesLawIsotropic2D
-   use m_MEF90_HookesLawIsotropic3D
+   use m_MEF90_HookesLaw_class, only: MEF90HookesLaw
+   use m_MEF90_HookesLawIsotropic2D, only: MEF90HookesLawIsotropic2D
+   use m_MEF90_HookesLawIsotropic3D, only: MEF90HookesLawIsotropic3D
    ! use m_MEF90_HookesLawZero
    use petscsys
    implicit none(type)

--- a/MEF90/m_MEF90_HookesLawClass.F90
+++ b/MEF90/m_MEF90_HookesLawClass.F90
@@ -1,9 +1,7 @@
 module m_MEF90_HookesLaw_class
 #include "petsc/finclude/petsc.h"
    use m_MEF90_Parameters
-   use m_MEF90_Utils
-   ! use m_MEF90_LinAlg
-   use m_MEF90_BaseClass
+   use m_MEF90_BaseClass, only: MEF90Object
    use petscsys
 
    implicit none(type, external)
@@ -26,7 +24,7 @@ module m_MEF90_HookesLaw_class
 
    abstract interface
       subroutine HookesLawMultInterface(A, phi, Aphi, ierr)
-         use m_MEF90_LinAlg_class
+         use m_MEF90_LinAlg_class, only: mef90Mat
          use petscsys
          import :: MEF90HookesLaw
 
@@ -37,7 +35,7 @@ module m_MEF90_HookesLaw_class
       end subroutine HookesLawMultInterface
 
       subroutine HookesLawMultMultInterface(A, phi, psi, Aphipsi, ierr)
-         use m_MEF90_LinAlg_class
+         use m_MEF90_LinAlg_class, only: mef90Mat
          use petscsys
          import :: MEF90HookesLaw
 

--- a/MEF90/m_MEF90_HookesLawIsotropic.F90
+++ b/MEF90/m_MEF90_HookesLawIsotropic.F90
@@ -1,9 +1,9 @@
 module m_MEF90_HookesLawIsotropic2D
 #include "petsc/finclude/petsc.h"
+   use petscsys
    use m_MEF90_Parameters
-   use m_MEF90_Utils
    use m_MEF90_LinAlg
-   use m_MEF90_HookesLaw_Class
+   use m_MEF90_HookesLaw_Class, only: MEF90HookesLaw
    use iso_c_binding
 
    implicit none(type)
@@ -146,10 +146,10 @@ end module m_MEF90_HookesLawIsotropic2D
 
 module m_MEF90_HookesLawIsotropic3D
 #include "petsc/finclude/petsc.h"
+   use petscsys
    use m_MEF90_Parameters
-   use m_MEF90_Utils
    use m_MEF90_LinAlg
-   use m_MEF90_HookesLaw_Class
+   use m_MEF90_HookesLaw_Class, only: MEF90HookesLaw
    use iso_c_binding
 
    implicit none(type)

--- a/MEF90/m_MEF90_HookesLawZero.F90
+++ b/MEF90/m_MEF90_HookesLawZero.F90
@@ -1,9 +1,9 @@
 module m_MEF90_HookesLawZero
 #include "petsc/finclude/petsc.h"
+   use petscsys
    use m_MEF90_Parameters
-   use m_MEF90_Utils
    use m_MEF90_LinAlg
-   use m_MEF90_HookesLaw_Class
+   use m_MEF90_HookesLaw_Class, only: MEF90HookesLaw
    use iso_c_binding
 
    implicit none(type)

--- a/MEF90/m_MEF90_LinAlg.F90
+++ b/MEF90/m_MEF90_LinAlg.F90
@@ -25,11 +25,30 @@ end module m_MEF90_LinAlg_class
 
 module m_MEF90_LinAlg
 #include "petsc/finclude/petsc.h"
-   use m_MEF90_LinAlg_class
+   use petscsys
+   use m_MEF90_LinAlg_class, only: mef90Vect, mef90Mat, mef90Tens4OS
    use m_MEF90_Parameters
-   use m_MEF90_Utils
 
    implicit none(type)
+   private
+   public :: mef90Vect, mef90Mat, mef90Tens4OS
+   public :: Vect2D, Vect3D
+   public :: Mat2D, MatS2D, Mat3D, MatS3D
+   public :: Tens4OS2D, Tens4OS3D
+   public :: MEF90Vect2De1, MEF90Vect2De2
+   public :: MEF90Vect3De1, MEF90Vect3De2, MEF90Vect3De3
+   public :: MEF90Mat2DIdentity, MEF90MatS2DIdentity
+   public :: MEF90Mat3DIdentity, MEF90MatS3DIdentity
+   public :: MEF90Tens4OS2DIdentity, MEF90Tens4OS3DIdentity
+   public :: operator(+), operator(-), operator(*), operator(/)
+   public :: operator(.DotP.), operator(.CrossP.)
+   public :: operator(.TensP.), operator(.SymP.), operator(.oDot.)
+   public :: Transpose, Invert, Trace, Det
+   public :: assignment(=)
+   public :: Symmetrize, DeviatoricPart, HydrostaticPart
+   public :: MEF90MatRaRt, MEF90MatRtaR
+   public :: Norm, simplexNormal, sqrt
+   public :: SpectralDecomposition, Diagonalize, Moment, Tens4OSTransform
 
    external :: dsyevd
    external :: dgetrf

--- a/MEF90/m_MEF90_MPI.F90
+++ b/MEF90/m_MEF90_MPI.F90
@@ -1,5 +1,6 @@
 module m_MEF90_MPI
 #include "petsc/finclude/petsc.h"
+   use petscsys
    use m_MEF90_Parameters
    implicit none(type, external)
 

--- a/MEF90/m_MEF90_MassMatrixImplementation.F90
+++ b/MEF90/m_MEF90_MassMatrixImplementation.F90
@@ -1,12 +1,11 @@
 #include "mef90.inc"
 module MEF90_APPEND(m_MEF90_MassMatrixImplementation_,MEF90_ELEMENTTYPE)
 #include "petsc/finclude/petsc.h"
+use petscdmplex
 use m_MEF90_Parameters
-use m_MEF90_Utils
 use m_MEF90_LinAlg
-use m_MEF90_Elements
-use m_MEF90_Ctx
-use m_MEF90_DMPlex
+use m_MEF90_Elements, only: MEF90ElementType, MEF90Element2DScal, MEF90Element2DVect, MEF90Element3DScal, MEF90Element3DVect
+use m_MEF90_DMPlex, only: MEF90SetLabelName
 implicit none(type, external)
 
 private

--- a/MEF90/m_MEF90_MassMatrixInterface.F90
+++ b/MEF90/m_MEF90_MassMatrixInterface.F90
@@ -1,9 +1,9 @@
 module m_MEF90_MassMatrixInterface
 #include "petsc/finclude/petsc.h"
-   use m_MEF90_MassMatrixImplementation_MEF90Element2DScal, MassMatrixAssembleSet2DScal => MEF90_MassMatrixAssembleSet
-   use m_MEF90_MassMatrixImplementation_MEF90Element2DVect, MassMatrixAssembleSet2DVect => MEF90_MassMatrixAssembleSet
-   use m_MEF90_MassMatrixImplementation_MEF90Element3DScal, MassMatrixAssembleSet3DScal => MEF90_MassMatrixAssembleSet
-   use m_MEF90_MassMatrixImplementation_MEF90Element3DVect, MassMatrixAssembleSet3DVect => MEF90_MassMatrixAssembleSet
+   use m_MEF90_MassMatrixImplementation_MEF90Element2DScal, only: MassMatrixAssembleSet2DScal => MEF90_MassMatrixAssembleSet
+   use m_MEF90_MassMatrixImplementation_MEF90Element2DVect, only: MassMatrixAssembleSet2DVect => MEF90_MassMatrixAssembleSet
+   use m_MEF90_MassMatrixImplementation_MEF90Element3DScal, only: MassMatrixAssembleSet3DScal => MEF90_MassMatrixAssembleSet
+   use m_MEF90_MassMatrixImplementation_MEF90Element3DVect, only: MassMatrixAssembleSet3DVect => MEF90_MassMatrixAssembleSet
 
    implicit none(type, external)
 

--- a/MEF90/m_MEF90_Materials.F90
+++ b/MEF90/m_MEF90_Materials.F90
@@ -1,10 +1,14 @@
 module m_MEF90_Materials_Types
 #include "petsc/finclude/petsc.h"
    use m_MEF90_Parameters
-   use m_MEF90_Utils
    use m_MEF90_LinAlg
    use petscbag
    implicit none(type, external)
+   private
+   public :: MEF90HookesLaw2D, MEF90HookesLaw3D, MEF90RotationMatrix3D
+   public :: MEF90MatProp2D_Type, MEF90MatProp3D_Type
+   public :: MEF90HookesLawTypeFull, MEF90HookesLawTypeIsotropic
+   public :: MEF90Mathium2D, MEF90Mathium3D
 
    type MEF90HookesLaw2D
       type(Tens4OS2D)    :: fullTensor
@@ -82,7 +86,8 @@ end module m_MEF90_Materials_Types
 
 module m_MEF90_Materials_Interface2D
 #include "petsc/finclude/petsc.h"
-   use m_MEF90_Materials_Types
+   use petscbag
+   use m_MEF90_Materials_Types, only: MEF90MatProp2D_Type
    implicit none(type)
    private
    public :: PetscBagGetDataMEF90MatProp2D
@@ -101,7 +106,8 @@ end module m_MEF90_Materials_Interface2D
 
 module m_MEF90_Materials_Interface3D
 #include "petsc/finclude/petsc.h"
-   use m_MEF90_Materials_Types
+   use petscbag
+   use m_MEF90_Materials_Types, only: MEF90MatProp3D_Type
    implicit none(type)
    private
    public :: PetscBagGetDataMEF90MatProp3D
@@ -120,16 +126,34 @@ end module m_MEF90_Materials_Interface3D
 
 module m_MEF90_Materials
 #include "petsc/finclude/petsc.h"
+   use petscbag
+   use petscdm
+   use petscis
    use m_MEF90_Parameters
-   use m_MEF90_Utils
+   use m_MEF90_Utils, only: MEF90ISAllGatherMerge
    use m_MEF90_LinAlg
-   use m_MEF90_Elements
-   use m_MEF90_Ctx
-   use m_MEF90_DMPlex
-   use m_MEF90_Materials_Types
-   use m_MEF90_Materials_Interface2D
-   use m_MEF90_Materials_Interface3D
+   use m_MEF90_Ctx, only: MEF90Ctx_Type, MEF90CtxGlobalOptions_Type, PetscBagGetDataMEF90CtxGlobalOptions
+   use m_MEF90_DMPlex, only: MEF90CellSetLabelName
+   use m_MEF90_Materials_Types, only: MEF90HookesLaw2D, MEF90HookesLaw3D, MEF90RotationMatrix3D, &
+      MEF90MatProp2D_Type, MEF90MatProp3D_Type, &
+      MEF90HookesLawTypeFull, MEF90HookesLawTypeIsotropic, &
+      MEF90Mathium2D, MEF90Mathium3D
+   use m_MEF90_Materials_Interface2D, only: PetscBagGetDataMEF90MatProp2D
+   use m_MEF90_Materials_Interface3D, only: PetscBagGetDataMEF90MatProp3D
    implicit none(type)
+   private
+   public :: PetscBagGetDataMEF90MatProp
+   public :: PetscBagRegisterMEF90MatProp
+   public :: MEF90MatPropBagSetFromOptions
+   public :: operator(+), operator(-), operator(*)
+   public :: sizeofMEF90MatProp2D, sizeofMEF90MatProp3D
+   public :: sizeofMEF90HookesLaw2D, sizeofMEF90HookesLaw3D
+   public :: MEF90HookesLawTypeList
+   public :: MEF90MaterialsInitialize_Private
+   public :: MEF90HookesLaw2D, MEF90HookesLaw3D, MEF90RotationMatrix3D
+   public :: MEF90MatProp2D_Type, MEF90MatProp3D_Type
+   public :: MEF90HookesLawTypeFull, MEF90HookesLawTypeIsotropic
+   public :: MEF90Mathium2D, MEF90Mathium3D
 
    interface PetscBagGetDataMEF90MatProp
       module procedure PetscBagGetDataMEF90MatProp2D, PetscBagGetDataMEF90MatProp3D

--- a/MEF90/m_MEF90_NormsImplementation.F90
+++ b/MEF90/m_MEF90_NormsImplementation.F90
@@ -2,12 +2,11 @@
 module MEF90_APPEND(m_MEF90_NormsImplementation_,MEF90_ELEMENTTYPE)
 
 #include "petsc/finclude/petsc.h"
+use petscdmplex
 use m_MEF90_Parameters
-use m_MEF90_Utils
 use m_MEF90_LinAlg
-use m_MEF90_Elements
-use m_MEF90_Ctx
-use m_MEF90_DMPlex
+use m_MEF90_Elements, only: MEF90ElementType, MEF90Element2DScal, MEF90Element2DVect, MEF90Element3DScal, MEF90Element3DVect
+use m_MEF90_DMPlex, only: MEF90SetLabelName
 implicit none(type, external)
 
 private

--- a/MEF90/m_MEF90_NormsInterface.F90
+++ b/MEF90/m_MEF90_NormsInterface.F90
@@ -1,16 +1,20 @@
 module m_MEF90_NormsInterface
 #include "petsc/finclude/petsc.h"
-   use m_MEF90_NormsImplementation_MEF90Element2DScal, MEF90L2DotProductSet2DScal => MEF90L2DotProductSet, &
+   use m_MEF90_NormsImplementation_MEF90Element2DScal, only: &
+      MEF90L2DotProductSet2DScal => MEF90L2DotProductSet, &
       MEF90H1DotProductSet2DScal => MEF90H1DotProductSet, &
       MEF90L2NormSet2DScal => MEF90L2NormSet
-   use m_MEF90_NormsImplementation_MEF90Element2DVect, MEF90L2DotProductSet2DVect => MEF90L2DotProductSet, &
+   use m_MEF90_NormsImplementation_MEF90Element2DVect, only: &
+      MEF90L2DotProductSet2DVect => MEF90L2DotProductSet, &
       MEF90H1DotProductSet2DVect => MEF90H1DotProductSet, &
       MEF90H1SymDotProductSet2DVect => MEF90H1SymDotProductSet, &
       MEF90L2NormSet2DVect => MEF90L2NormSet
-   use m_MEF90_NormsImplementation_MEF90Element3DScal, MEF90L2DotProductSet3DScal => MEF90L2DotProductSet, &
+   use m_MEF90_NormsImplementation_MEF90Element3DScal, only: &
+      MEF90L2DotProductSet3DScal => MEF90L2DotProductSet, &
       MEF90H1DotProductSet3DScal => MEF90H1DotProductSet, &
       MEF90L2NormSet3DScal => MEF90L2NormSet
-   use m_MEF90_NormsImplementation_MEF90Element3DVect, MEF90L2DotProductSet3DVect => MEF90L2DotProductSet, &
+   use m_MEF90_NormsImplementation_MEF90Element3DVect, only: &
+      MEF90L2DotProductSet3DVect => MEF90L2DotProductSet, &
       MEF90H1DotProductSet3DVect => MEF90H1DotProductSet, &
       MEF90H1SymDotProductSet3DVect => MEF90H1SymDotProductSet, &
       MEF90L2NormSet3DVect => MEF90L2NormSet

--- a/MEF90/m_MEF90_Parameters.F90
+++ b/MEF90/m_MEF90_Parameters.F90
@@ -4,22 +4,28 @@ module m_MEF90_Parameters
 
    use petscsys
    implicit none(type, external)
-#include "exodusII.inc"
+! #include "exodusII.inc"
 #include "../mef90version.h"
+
+   private
+   public :: Ki, Kr, MEF90MXSTRLEN, MEF90INFINITY, MEF90NINFINITY
 
    ! The following ensures that mef90 and PETSC real types are compatible:
    ! thanks to Michael Metcalf in comp.lang.fortran
-   PetscReal, parameter                  :: PReal = 1.0
-   integer, parameter, public            :: Kr = selected_real_kind(precision(PReal))
+   ! PetscReal, parameter          :: PReal = 1.0
+   ! integer, parameter            :: Kr = selected_real_kind(precision(PReal))
 
-   PetscInt, parameter                   :: PInt = 1
-   integer, parameter, public            :: Ki = kind(PInt)
+   ! PetscInt, parameter           :: PInt = 1
+   ! integer, parameter            :: Ki = kind(PInt)
 
-   PetscLogDouble, parameter             :: flop = 1.0
-   integer, parameter, public            :: PFlop = selected_real_kind(precision(flop))
+   ! PetscLogDouble, parameter     :: flop = 1.0
+   ! integer, parameter            :: PFlop = selected_real_kind(precision(flop))
 
-   PetscInt, parameter, public           :: MEF90MXSTRLEN = 256
+   integer, parameter            :: Kr = PETSC_REAL_KIND
+   integer, parameter            :: Ki = PETSC_INT_KIND
 
-   PetscReal, parameter, public          :: MEF90INFINITY = huge(1.0_kr)
-   PetscReal, parameter, public          :: MEF90NINFINITY = -huge(1.0_kr)
+   PetscInt, parameter           :: MEF90MXSTRLEN = 256
+
+   PetscReal, parameter          :: MEF90INFINITY = huge(1.0_kr)
+   PetscReal, parameter          :: MEF90NINFINITY = -huge(1.0_kr)
 end module m_MEF90_Parameters

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -17,147 +17,147 @@ include ${MEF90_DIR}/m_DefMech/Makefile.include
 
 TestEXOFormat.o: ${MEF90_DIR}/Tests/TestEXOFormat.F90 MEF90
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestEXOFormat: TestEXOFormat.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SYMENGINEF90_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SYMENGINEF90_LIB}
 	-@${RM} $<
 
 TestHookesLaw_Type.o: ${MEF90_DIR}/Tests/TestHookesLaw_Type.F90 MEF90
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestHookesLaw_Type: TestHookesLaw_Type.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SYMENGINEF90_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SYMENGINEF90_LIB}
 	-@${RM} $<
 
 TestLinAlg.o: ${MEF90_DIR}/Tests/TestLinAlg.F90 MEF90
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestLinAlg: TestLinAlg.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SYMENGINEF90_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SYMENGINEF90_LIB}
 	-@${RM} $<
 
 TestParser.o: ${MEF90_DIR}/Tests/TestParser.F90 MEF90
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestParser: TestParser.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SYMENGINEF90_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SYMENGINEF90_LIB}
 	-@${RM} $<
 
 TestOffsets.o: ${MEF90_DIR}/Tests/TestOffsets.F90 MEF90
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestOffsets: TestOffsets.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestLog.o: ${MEF90_DIR}/Tests/TestLog.F90 MEF90
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestLog: TestLog.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestOrientation.o: ${MEF90_DIR}/Tests/TestOrientation.F90 MEF90
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestOrientation: TestOrientation.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestDotProduct.o: ${MEF90_DIR}/Tests/TestDotProduct.F90 MEF90
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestDotProduct: TestDotProduct.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestMassMatrix.o: ${MEF90_DIR}/Tests/TestMassMatrix.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestMassMatrix: TestMassMatrix.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestHeatXferCtx.o: ${MEF90_DIR}/Tests/TestHeatXferCtx.F90 MEF90 m_HeatXfer
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestHeatXferCtx: TestHeatXferCtx.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestMEF90Ctx.o: ${MEF90_DIR}/Tests/TestMEF90Ctx.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestMEF90Ctx: TestMEF90Ctx.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestSection.o: ${MEF90_DIR}/Tests/TestSection.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestSection: TestSection.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestConstraints.o: ${MEF90_DIR}/Tests/TestConstraints.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestConstraints: TestConstraints.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestConstraintIO.o: ${MEF90_DIR}/Tests/TestConstraintIO.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestConstraintIO: TestConstraintIO.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestConstraintIO2.o: ${MEF90_DIR}/Tests/TestConstraintIO2.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestConstraintIO2: TestConstraintIO2.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestConstraintIO3.o: ${MEF90_DIR}/Tests/TestConstraintIO3.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestConstraintIO3: TestConstraintIO3.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestConstraintIO4.o: ${MEF90_DIR}/Tests/TestConstraintIO4.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestConstraintIO4: TestConstraintIO4.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 # TestMaterials is a false positive
@@ -171,161 +171,161 @@ TestConstraintIO4: TestConstraintIO4.o
 
 TestVec.o: ${MEF90_DIR}/Tests/TestVec.F90 MEF90
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestVec: TestVec.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestDMPlexVecGetClosure.o: ${MEF90_DIR}/Tests/TestDMPlexVecGetClosure.F90 MEF90
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestDMPlexVecGetClosure: TestDMPlexVecGetClosure.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestVecSetBCFromOptions.o: ${MEF90_DIR}/Tests/TestVecSetBCFromOptions.F90 MEF90
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestVecSetBCFromOptions: TestVecSetBCFromOptions.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestVecSetBCFromOptionsExpr.o: ${MEF90_DIR}/Tests/TestVecSetBCFromOptionsExpr.F90 MEF90
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestVecSetBCFromOptionsExpr: TestVecSetBCFromOptionsExpr.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestLabels.o: ${MEF90_DIR}/Tests/TestLabels.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestLabels: TestLabels.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestATClass.o: ${MEF90_DIR}/Tests/TestATClass.F90 MEF90 m_DefMech
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestATClass: TestATClass.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestSNLP.o: ${MEF90_DIR}/Tests/TestSNLP.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestSNLP: TestSNLP.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB}
 	-@${RM} $<
 
 TestVonMises2D.o: ${MEF90_DIR}/Tests/TestVonMises2D.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestVonMises2D: TestVonMises2D.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB}
 	-@${RM} $<
 
 TestVonMises3D.o: ${MEF90_DIR}/Tests/TestVonMises3D.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestVonMises3D: TestVonMises3D.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB}
 	-@${RM} $<
 
 ### Old stuff
 # TestDofOrdering was used to figure out petsc dof ordering. It is not needed on a regular basis
 TestDofOrdering.o: ${MEF90_DIR}/Tests/TestDofOrdering.F90 MEF90 m_HeatXfer
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestDofOrdering: TestDofOrdering.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestDMPlexComputeCellGeometryAffineFEM: TestDMPlexComputeCellGeometryAffineFEM.o
-	-@${CLINKER} -o TestDMPlexComputeCellGeometryAffineFEM TestDMPlexComputeCellGeometryAffineFEM.o ${PETSC_LIB}
+	@${CLINKER} -o TestDMPlexComputeCellGeometryAffineFEM TestDMPlexComputeCellGeometryAffineFEM.o ${PETSC_LIB}
 	${RM} -f TestDMPlexComputeCellGeometryAffineFEM.o
 
 TestDMPlexComputeCellGeometryAffineFEMF90: TestDMPlexComputeCellGeometryAffineFEMF90.o
-	-@${FLINKER} -o TestDMPlexComputeCellGeometryAffineFEMF90 TestDMPlexComputeCellGeometryAffineFEMF90.o ${PETSC_LIB} ${PETSC_FORTRAN_LIB}
+	@${FLINKER} -o TestDMPlexComputeCellGeometryAffineFEMF90 TestDMPlexComputeCellGeometryAffineFEMF90.o ${PETSC_LIB} ${PETSC_FORTRAN_LIB}
 	${RM} -f TestDMPlexComputeCellGeometryAffineFEMF90.o
 
 TestEXOReadPart.o: ${MEF90_DIR}/Tests/TestEXOReadPart.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestEXOReadPart: TestEXOReadPart.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB}
 	-@${RM} $<
 
 TestDMPlexComputeGeometryTri.o: ${MEF90_DIR}/Tests/TestDMPlexComputeGeometryTri.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestDMPlexComputeGeometryTri: TestDMPlexComputeGeometryTri.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB}
 	-@${RM} $<
 
 TestDMPlexComputeGeometryQuad.o: ${MEF90_DIR}/Tests/TestDMPlexComputeGeometryQuad.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestDMPlexComputeGeometryQuad: TestDMPlexComputeGeometryQuad.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB}
 	-@${RM} $<
 
 TestQuadrature.o: ${MEF90_DIR}/Tests/TestQuadrature.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestQuadrature: TestQuadrature.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestSpectralDecomposition.o: ${MEF90_DIR}/Tests/TestSpectralDecomposition.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestSpectralDecomposition: TestSpectralDecomposition.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestMasonry.o: ${MEF90_DIR}/Tests/TestMasonry.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_DIM=3 -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_DIM=3 -c -o $@ $<
 
 TestMasonry: TestMasonry.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestHD.o: ${MEF90_DIR}/Tests/TestHD.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_DIM=3 -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_DIM=3 -c -o $@ $<
 
 TestHD: TestHD.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestTresca3D.o: ${MEF90_DIR}/Tests/TestTresca3D.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 TestTresca3D: TestTresca3D.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestTresca2D.o: ${MEF90_DIR}/Tests/TestTresca2D.F90 MEF90
@@ -333,7 +333,7 @@ TestTresca2D.o: ${MEF90_DIR}/Tests/TestTresca2D.F90 MEF90
 
 TestTresca2D: TestTresca2D.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 ###

--- a/ThermoElasticity/Makefile
+++ b/ThermoElasticity/Makefile
@@ -1,6 +1,6 @@
 NP=4 
 all:
-	-@${MAKE} -C ${MEF90_DIR} ThermoElasticity
+	@${MAKE} -C ${MEF90_DIR} ThermoElasticity
 test: test2D test3D
 test2D: ${MEF90_DIR}/${PETSC_ARCH}/bin/ThermoElasticity
 	-@for i in {1..4}; do \
@@ -27,15 +27,15 @@ ThermoElasticity:${MEF90_DIR}/${PETSC_ARCH}/bin/ThermoElasticity ${MEF90_OBJS} $
 
 ${MEF90_DIR}/${PETSC_ARCH}/bin/ThermoElasticity: ThermoElasticity.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} 
 	-@echo "      $@"
-	-@${FLINKER} -o $@ ThermoElasticity.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB}
+	@${FLINKER} -o $@ ThermoElasticity.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB}
 
 ThermoElasticity.o: ${BASE_DIR}/ThermoElasticity.F90 ${MEF90_OBJS}  ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} m_vDefDefault.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_vDefDefault.o: ${BASE_DIR}/m_vDefDefault.F90 ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 
 

--- a/ThermoElasticity/ThermoElasticity.F90
+++ b/ThermoElasticity/ThermoElasticity.F90
@@ -7,6 +7,8 @@ program ThermoElasticity
    use m_MEF90_HeatXfer
    use m_MEF90_HeatXferCtx
    use m_vDefDefault
+   use m_MEF90_EXO, only: MEF90CtxOpenEXO, MEF90EXODMView
+   use m_MEF90_Utils, only: MEF90ISAllGatherMerge
    implicit none(type, external)
 
    PetscErrorCode                                     :: ierr

--- a/ThermoElasticity/m_vDefDefault.F90
+++ b/ThermoElasticity/m_vDefDefault.F90
@@ -57,14 +57,11 @@ module m_vDefDefault
    type(MEF90DefMechCellSetOptions_Type), parameter    :: DefMechDefaultCellSetOptions = MEF90DefMechCellSetOptions_Type( &
                                                           [0.0_kr, 0.0_kr, 0.0_kr], & ! bodyForce
                                                           0.0_kr, & ! crackPressure
-                                                          MEF90DefMech_damageTypeAT1, & ! damageType
+                                                         !  MEF90DefMech_damageTypeAT1, & ! damageType
                                                           MEF90DefMech_plasticityTypeNone, & ! plasticityType
-                                                          MEF90DefMech_unilateralContactTypeNone, & ! unilateralContactType
-                                                          1.0e-5, & ! unilateralContactHydrostaticDeviatoricGamma
-                                                          PETSC_FALSE, & ! unilateralContactHybrid
-                                                          1.0_kr, & ! damageATLinSoftk
-                                                          1.25_kr, & ! damageAT1expb
-                                                          MEF90DefMech_drivingForceTypeNone, & ! drivingForceType
+                                                         !  MEF90DefMech_unilateralContactTypeNone, & ! unilateralContactType
+                                                         !  1.0e-5, & ! unilateralContactHydrostaticDeviatoricGamma
+                                                         !  PETSC_FALSE, & ! unilateralContactHybrid
                                                           [0.0_kr, 0.0_kr, 0.0_kr], & ! cohesiveDisplacement
                                                           [PETSC_FALSE, PETSC_FALSE, PETSC_FALSE], & ! hasDisplacementBC
                                                           [0.0_kr, 0.0_kr, 0.0_kr], & ! boundaryDisplacement

--- a/ThermoElasticity/m_vDefDefault.F90
+++ b/ThermoElasticity/m_vDefDefault.F90
@@ -4,6 +4,7 @@ module m_vDefDefault
    use petsc
    use m_MEF90
    use m_MEF90_DefMechCtx
+   use m_MEF90_DefMechAT, only: MEF90DefMech_damageTypeAT1, MEF90DefMech_damageTypeAT1exp, MEF90DefMech_damageTypeAT2, MEF90DefMech_damageTypeKKL
    use m_MEF90_HeatXferCtx
    implicit none(type, external)
 

--- a/ThermoElastoPlasticity/Makefile
+++ b/ThermoElastoPlasticity/Makefile
@@ -1,6 +1,6 @@
 NP=2 
 all:
-	-@${MAKE} -C ${MEF90_DIR} ThermoElastoPlasticity
+	@${MAKE} -C ${MEF90_DIR} ThermoElastoPlasticity
 test: test2D test3D
 test2D: ${MEF90_DIR}/bin/${PETSC_ARCH}/ThermoElastoPlasticity
 	-@for OPTIONSFILE in test1.opts test2.opts test3.opts test4.opts; do \
@@ -34,11 +34,11 @@ ThermoElastoPlasticity:${MEF90_DIR}/bin/${PETSC_ARCH}/ThermoElastoPlasticity
 
 ${MEF90_DIR}/bin/${PETSC_ARCH}/ThermoElastoPlasticity: ThermoElastoPlasticity.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} 
 	-@echo "      $@"
-	-@${FLINKER} -o $@ ThermoElastoPlasticity.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB}
+	@${FLINKER} -o $@ ThermoElastoPlasticity.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB}
 
 ThermoElastoPlasticity.o: ${BASE_DIR}/ThermoElastoPlasticity.F90 ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 testThermoElastoPlasticity:
 	@echo ;echo "Testing ThermoElastoPlasticity with $${PREFIX} $${OPTIONSFILE}"

--- a/Utils/Makefile
+++ b/Utils/Makefile
@@ -9,7 +9,7 @@ include ${MEF90_DIR}/m_DefMech/Makefile.include
 
 ### Tools
 ${MEF90_DIR}/${PETSC_ARCH}/bin/viewDAG: viewDAG.o
-	-@${CLINKER} -o viewDAG viewDAG.o ${PETSC_LIB}
+	@${CLINKER} -o viewDAG viewDAG.o ${PETSC_LIB}
 	-@${RM} -f viewDAG.o
 
 viewDAG:${MEF90_DIR}/${PETSC_ARCH}/bin/viewDAG
@@ -17,7 +17,7 @@ viewDAG:${MEF90_DIR}/${PETSC_ARCH}/bin/viewDAG
 	-@cp viewDAG ${MEF90_DIR}/${PETSC_ARCH}/bin/viewDAG
 
 ${MEF90_DIR}/${PETSC_ARCH}/bin/viewSets: viewSets.o
-	-@${CLINKER} -o viewSets viewSets.o ${PETSC_LIB}
+	@${CLINKER} -o viewSets viewSets.o ${PETSC_LIB}
 	-@${RM} -f viewSets.o
 
 viewSets:${MEF90_DIR}/${PETSC_ARCH}/bin/viewSets
@@ -30,22 +30,22 @@ gmsh2exo:${MEF90_DIR}/${PETSC_ARCH}/bin/gmsh2exo
 	-@echo "      $@"
 
 gmsh2exo.o: ${MEF90_DIR}/Utils/gmsh2exo.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 ${MEF90_DIR}/${PETSC_ARCH}/bin/gmsh2exo: gmsh2exo.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 TestOrientation:${MEF90_DIR}/${PETSC_ARCH}/bin/TestOrientation
 	-@echo "      $@"
 
 TestOrientation.o: ${MEF90_DIR}/Utils/TestOrientation.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 ${MEF90_DIR}/${PETSC_ARCH}/bin/TestOrientation: TestOrientation.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 YAMLValidator.o: ${MEF90_DIR}/Utils/YAMLValidator.F90 
@@ -56,17 +56,17 @@ YAMLValidator:${MEF90_DIR}/${PETSC_ARCH}/bin/YAMLValidator
 
 ${MEF90_DIR}/${PETSC_ARCH}/bin/YAMLValidator: YAMLValidator.o
 	-@echo "      $@"
-	-@${FLINKER} -o $@ YAMLValidator.o ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} 
+	@${FLINKER} -o $@ YAMLValidator.o ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} 
 
 HookeLaws:${MEF90_DIR}/${PETSC_ARCH}/bin/HookeLaws
 	-@echo "      $@"
 
 HookeLaws.o: ${MEF90_DIR}/Utils/HookeLaws.F90 MEF90
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 ${MEF90_DIR}/${PETSC_ARCH}/bin/HookeLaws: HookeLaws.o
 	-@echo " $@"
-	-@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
+	@${FLINKER} -o $@ $< ${MEF90_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB}
 	-@${RM} $<
 
 MEF90:

--- a/Utils/gmsh2exo.F90
+++ b/Utils/gmsh2exo.F90
@@ -1,6 +1,10 @@
 program gmsh2exo
 #include <petsc/finclude/petsc.h>
    use m_MEF90
+   use m_MEF90_Ctx, only: MEF90Ctx_Type, MEF90CtxGlobalOptions_Type, MEF90CtxCreate, MEF90CtxDestroy, &
+                          MEF90TimeInterpolation_linear, MEF90ElementFamilyLagrange
+   use m_MEF90_Parameters, only: kr
+   use m_MEF90_EXO, only: MEF90CtxOpenEXO, MEF90EXODMView
    use petsc
    implicit none(type, external)
 

--- a/WorkControlled/Makefile
+++ b/WorkControlled/Makefile
@@ -1,6 +1,6 @@
 NP=2 
 all:
-	-@${MAKE} -C ${MEF90_DIR} WorkControlled
+	@${MAKE} -C ${MEF90_DIR} WorkControlled
 test: test2D test3D
 test2D: ${MEF90_DIR}/bin/${PETSC_ARCH}/WorkControlled
 	-@for OPTIONSFILE in test7.yaml test8.yaml; do \
@@ -28,11 +28,11 @@ WorkControlled:${MEF90_DIR}/bin/${PETSC_ARCH}/WorkControlled
 
 ${MEF90_DIR}/bin/${PETSC_ARCH}/WorkControlled: WorkControlled.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS}  ${MEF90_HEATXFER_OBJS}
 	-@echo "      $@"
-	-@${FLINKER} -o $@ WorkControlled.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB}
+	@${FLINKER} -o $@ WorkControlled.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB}
 
 WorkControlled.o: ${BASE_DIR}/WorkControlled.F90 ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 testWorkControlled:
 	@echo ;echo "Testing WorkControlled with $${PREFIX} $${OPTIONSFILE}"

--- a/WorkControlled/WorkControlled.F90
+++ b/WorkControlled/WorkControlled.F90
@@ -3,11 +3,17 @@ Program WorkControlled
 #include <finclude/petscdef.h>
    Use petsc
    Use m_MEF90
+   Use m_MEF90_Ctx, only: MEF90Ctx_Type, MEF90CtxGlobalOptions_Type, MEF90CtxCreate, MEF90CtxDestroy, &
+                          MEF90CtxGetTime, PetscBagGetDataMEF90CtxGlobalOptions
+   Use m_MEF90_DMPlex, only: MEF90CellSetLabelName, MEF90FaceSetLabelName, MEF90VertexSetLabelName
+   Use m_MEF90_Parameters, only: MEF90MXSTRLEN, kr, ki
    !Use m_vDef
    Use m_MEF90_DefMechCtx
    Use m_MEF90_DefMech
    Use m_MEF90_HeatXferCtx
    Use m_MEF90_HeatXfer
+   Use m_MEF90_EXO, only: MEF90CtxOpenEXO
+   Use m_MEF90_Utils, only: MEF90ISAllGatherMerge, MEF90FilePrefix
    implicit none (type, external)
 
    PetscErrorCode                                     :: ierr

--- a/m_DefMech/Makefile
+++ b/m_DefMech/Makefile
@@ -18,67 +18,67 @@ m_DefMech:m_MEF90_DefMech.o m_MEF90_DefMechCtx.o
 
 m_MEF90_DefMech.o: ${BASE_DIR}/m_MEF90_DefMech.F90 m_MEF90_DefMechCtx.o m_MEF90_DefMechAT.o m_MEF90_DefMechSplit.o m_MEF90_DefMechPlasticity2D.o  m_MEF90_DefMechPlasticity3D.o m_MEF90_DefMechAssembly2D.o  m_MEF90_DefMechAssembly3D.o 
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DefMechATClass.o: ${BASE_DIR}/m_MEF90_DefMechATClass.F90 m_MEF90_DefMechCtx.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DefMechAT1.o: ${BASE_DIR}/m_MEF90_DefMechAT1.F90 m_MEF90_DefMechATClass.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DefMechAT1Exp.o: ${BASE_DIR}/m_MEF90_DefMechAT1Exp.F90 m_MEF90_DefMechATClass.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DefMechAT2.o: ${BASE_DIR}/m_MEF90_DefMechAT2.F90 m_MEF90_DefMechATClass.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DefMechATKKL.o: ${BASE_DIR}/m_MEF90_DefMechATKKL.F90 m_MEF90_DefMechATClass.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DefMechATLinSoft.o: ${BASE_DIR}/m_MEF90_DefMechATLinSoft.F90 m_MEF90_DefMechATClass.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DefMechAT.o: ${BASE_DIR}/m_MEF90_DefMechAT.F90 m_MEF90_DefMechAT1.o m_MEF90_DefMechAT2.o m_MEF90_DefMechAT1Exp.o m_MEF90_DefMechATKKL.o #m_MEF90_DefMechATLinSoft.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DefMechSplitClass.o: ${BASE_DIR}/m_MEF90_DefMechSplitClass.F90 m_MEF90_DefMechCtx.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DefMechSplit.o: ${BASE_DIR}/m_MEF90_DefMechSplit.F90 m_MEF90_DefMechSplitNone.o m_MEF90_DefMechSplitHD.o m_MEF90_DefMechSplitDeviatoric.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DefMechSplitNone.o: ${BASE_DIR}/m_MEF90_DefMechSplitNone.F90 m_MEF90_DefMechSplitClass.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DefMechSplitHD.o: ${BASE_DIR}/m_MEF90_DefMechSplitHD.F90 m_MEF90_DefMechSplitClass.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DefMechSplitDeviatoric.o: ${BASE_DIR}/m_MEF90_DefMechSplitDeviatoric.F90 m_MEF90_DefMechSplitClass.o
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_DefMechAssembly2D.o: ${BASE_DIR}/m_MEF90_DefMechAssembly.F90 m_MEF90_DefMechSplit.o m_MEF90_DefMechAT.o m_MEF90_DefMechCtx.o
 	@echo "      $< MEF90_DIM=2"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_DIM=2 -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_DIM=2 -c -o $@ $<
 
 m_MEF90_DefMechAssembly3D.o: ${BASE_DIR}/m_MEF90_DefMechAssembly.F90 m_MEF90_DefMechSplit.o m_MEF90_DefMechAT.o m_MEF90_DefMechCtx.o
 	@echo "      $< MEF90_DIM=3"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_DIM=3 -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_DIM=3 -c -o $@ $<
 
 m_MEF90_DefMechCtx.o: ${BASE_DIR}/m_MEF90_DefMechCtx.F90
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 	
 m_MEF90_DefMechPlasticity2D.o: ${BASE_DIR}/m_MEF90_DefMechPlasticity.F90 m_MEF90_DefMechCtx.o #m_MEF90_DefMechPlasticityNone2D.o \
                    m_MEF90_DefMechPlasticityCap2D.o m_MEF90_DefMechPlasticityDruckerPragerCap2D.o \

--- a/m_DefMech/m_MEF90_DefMech.F90
+++ b/m_DefMech/m_MEF90_DefMech.F90
@@ -4,11 +4,16 @@ module m_MEF90_DefMech
    use petscsnes
    use petsctao
 
-   use m_MEF90_EXO
-   use m_MEF90_DefMechCtx
-   use m_MEF90_DefMechAT
+   use m_MEF90_Parameters, only: Kr, Ki, MEF90MxStrLen, MXSTLN
+   use m_MEF90_Ctx, only: MEF90CtxGlobalOptions_Type, PetscBagGetDataMEF90CtxGlobalOptions, &
+                          MEF90Scaling_CST, MEF90Scaling_Expr, MEF90Scaling_File, MEF90Scaling_Linear
+   use m_MEF90_DMPlex, only: MEF90VecCopySF, MEF90VecSetBCValuesFromOptions, MEF90VecSetBCValuesFromOptionsExpr, &
+                             MEF90VecSetValuesFromOptions, MEF90VecSetValuesFromOptionsExpr
+   use m_MEF90_EXO, only: MEF90EXOFormat, MEF90EXOVecLoad, MEF90EXOVecView
+   use m_MEF90_DefMechCtx, only: MEF90DefMechCtx_Type, MEF90DefMechGlobalOptions_Type, &
+                                 PetscBagGetDataMEF90DefMechCtxGlobalOptions
 
-   use m_MEF90_DefMechAssembly2D, &
+   use m_MEF90_DefMechAssembly2D, only: &
       MEF90DefMechOperatorDisplacement2D => MEF90DefMechOperatorDisplacement, &
       MEF90DefMechBilinearFormDisplacement2D => MEF90DefMechBilinearFormDisplacement, &
       MEF90DefMechWork2D => MEF90DefMechWork, &
@@ -23,9 +28,9 @@ module m_MEF90_DefMech
       MEF90DefMechTAOObjectiveDamage2D => MEF90DefMechTAOObjectiveDamage, &
       MEF90DefMechCrackVolume2D => MEF90DefMechCrackVolume, &
       MEF90DefMechStress2D => MEF90DefMechStress
-   use m_MEF90_DefMechPlasticity2D, &
+   use m_MEF90_DefMechPlasticity2D, only: &
       MEF90DefMechPlasticStrainUpdate2D => MEF90DefMechPlasticStrainUpdate
-   use m_MEF90_DefMechAssembly3D, &
+   use m_MEF90_DefMechAssembly3D, only: &
       MEF90DefMechOperatorDisplacement3D => MEF90DefMechOperatorDisplacement, &
       MEF90DefMechBilinearFormDisplacement3D => MEF90DefMechBilinearFormDisplacement, &
       MEF90DefMechWork3D => MEF90DefMechWork, &
@@ -40,7 +45,7 @@ module m_MEF90_DefMech
       MEF90DefMechTAOObjectiveDamage3D => MEF90DefMechTAOObjectiveDamage, &
       MEF90DefMechCrackVolume3D => MEF90DefMechCrackVolume, &
       MEF90DefMechStress3D => MEF90DefMechStress
-   use m_MEF90_DefMechPlasticity3D, &
+   use m_MEF90_DefMechPlasticity3D, only: &
       MEF90DefMechPlasticStrainUpdate3D => MEF90DefMechPlasticStrainUpdate
 
    implicit none(type)

--- a/m_DefMech/m_MEF90_DefMech.F90
+++ b/m_DefMech/m_MEF90_DefMech.F90
@@ -5,7 +5,7 @@ module m_MEF90_DefMech
    use petsctao
    use petscdmplex
 
-   use m_MEF90_Parameters, only: Kr, Ki, MEF90MxStrLen, MXSTLN
+   use m_MEF90_Parameters, only: Kr, Ki, MEF90MxStrLen
    use m_MEF90_Ctx, only: MEF90CtxGlobalOptions_Type, PetscBagGetDataMEF90CtxGlobalOptions, &
                           MEF90Scaling_CST, MEF90Scaling_Expr, MEF90Scaling_File, MEF90Scaling_Linear
    use m_MEF90_DMPlex, only: MEF90VecCopySF, MEF90VecSetBCValuesFromOptions, MEF90VecSetBCValuesFromOptionsExpr, &
@@ -50,6 +50,7 @@ module m_MEF90_DefMech
       MEF90DefMechPlasticStrainUpdate3D => MEF90DefMechPlasticStrainUpdate
 
    implicit none(type)
+#include "exodusII.inc"
    ! private
    public :: MEF90DefMechSetTransients
    public :: MEF90DefMechOperatorDisplacement

--- a/m_DefMech/m_MEF90_DefMech.F90
+++ b/m_DefMech/m_MEF90_DefMech.F90
@@ -3,6 +3,7 @@ module m_MEF90_DefMech
 #include "petsc/finclude/petsc.h"
    use petscsnes
    use petsctao
+   use petscdmplex
 
    use m_MEF90_Parameters, only: Kr, Ki, MEF90MxStrLen, MXSTLN
    use m_MEF90_Ctx, only: MEF90CtxGlobalOptions_Type, PetscBagGetDataMEF90CtxGlobalOptions, &

--- a/m_DefMech/m_MEF90_DefMechAT.F90
+++ b/m_DefMech/m_MEF90_DefMechAT.F90
@@ -14,6 +14,9 @@ module m_MEF90_DefMechAT
    private
    public :: MEF90DefMechGetATModel
    public :: MEF90DefMechAT_Type
+   public :: MEF90DefMech_damageTypeAT1, MEF90DefMech_damageTypeAT1exp, &
+             MEF90DefMech_damageTypeAT2, MEF90DefMech_damageTypeKKL, &
+             MEF90DefMech_damageTypeList
 
    enum, bind(c)
       enumerator :: MEF90DefMech_damageTypeAT1 = 0, &

--- a/m_DefMech/m_MEF90_DefMechAssembly.F90
+++ b/m_DefMech/m_MEF90_DefMechAssembly.F90
@@ -5,14 +5,29 @@ module MEF90_APPEND(m_MEF90_DefMechAssembly,MEF90_DIM)D
 
 use petscsnes
 use petsctao
-use m_MEF90_DefMechCtx
-use m_MEF90_Materials
-use m_MEF90_HookesLaw
-use m_MEF90_DefMechSplit
-use m_MEF90_DefMechAT
+use petscdmplex
+use m_MEF90_Parameters, only: Kr, Ki, MEF90MxStrLen
+use m_MEF90_LinAlg, only: MEF90_VECT, MEF90_MAT, MEF90_MATS, MEF90_TENS4OS, &
+                          operator(*), operator(+), operator(-), operator(/), &
+                          operator(.DotP.), assignment(=)
+use m_MEF90_Elements, only: MEF90_ELEMENT_SCAL, MEF90_ELEMENT_VECT, MEF90ElementType, &
+                            MEF90ElementGetType, MEF90ElementGetTypeBoundary, &
+                            MEF90ElementCreate, MEF90ElementDestroy
+use m_MEF90_Utils, only: MEF90ISAllGatherMerge
+use m_MEF90_Ctx, only: MEF90CtxGlobalOptions_Type, PetscBagGetDataMEF90CtxGlobalOptions
+use m_MEF90_DMPlex, only: MEF90CellSetLabelName, MEF90FaceSetLabelName
+use m_MEF90_DefMechCtx, only: MEF90DefMechCtx_Type, MEF90DefMechGlobalOptions_Type, &
+                              MEF90DefMechCellSetOptions_Type, MEF90DefMechFaceSetOptions_Type, &
+                              PetscBagGetDataMEF90DefMechCtxGlobalOptions, &
+                              PetscBagGetDataMEF90DefMechCtxCellSetOptions, &
+                              PetscBagGetDataMEF90DefMechCtxFaceSetOptions
+use m_MEF90_Materials, only: MEF90_MATPROP, PetscBagGetDataMEF90MatProp
+use m_MEF90_HookesLaw, only: MEF90HookesLaw, MEF90GetHookesLaw
+use m_MEF90_DefMechSplit, only: MEF90DefMechSplit, MEF90DefMechGetSplit
+use m_MEF90_DefMechAT, only: MEF90DefMechAT_Type, MEF90DefMechGetATModel
 
 implicit none(type, external)
-! Private
+private
 public MEF90DefMechOperatorDisplacement, &
    MEF90DefMechBilinearFormDisplacement, &
    MEF90DefMechWork, &

--- a/m_DefMech/m_MEF90_DefMechCtx.F90
+++ b/m_DefMech/m_MEF90_DefMechCtx.F90
@@ -1,5 +1,9 @@
 module m_MEF90_DefMechCtx_Type
 #include "petsc/finclude/petsc.h"
+   use petscsys
+   use petscdmplex
+   use petscbag
+   use, intrinsic :: iso_c_binding
    use m_MEF90_Ctx
    implicit none(type, external)
 
@@ -238,7 +242,16 @@ end module m_MEF90DefMechVertexSetOptions_Private
 
 module m_MEF90_DefMechCtx
 #include "petsc/finclude/petsc.h"
+   use petscsys
+   use petscdmplex
+   use petscbag
+   use, intrinsic :: iso_c_binding
+   use m_MEF90_Parameters
+   use m_MEF90_LinAlg
+   use m_MEF90_Ctx
    use m_MEF90_DMPlex
+   use m_MEF90_Utils, only: MEF90ISAllGatherMerge, MEF90FilePrefix
+   use m_MEF90_Materials
    use m_MEF90_DefMechCtx_Type
    use m_MEF90DefMechGlobalOptions_Private
    use m_MEF90DefMechCellSetOptions_Private

--- a/m_DefMech/m_MEF90_DefMechSplitClass.F90
+++ b/m_DefMech/m_MEF90_DefMechSplitClass.F90
@@ -2,6 +2,8 @@
 module m_MEF90_DefMechSplit_class
 #include "petsc/finclude/petsc.h"
 
+use petscsys
+use, intrinsic :: iso_c_binding
 use m_MEF90_LinAlg_class
 use m_MEF90_Parameters
 use m_MEF90_BaseClass
@@ -9,6 +11,9 @@ use m_MEF90_HookesLaw_Class
 implicit none(type, external)
 private
 public :: MEF90DefMechSplit
+public :: mef90Mat
+public :: MEF90MXSTRLEN
+public :: kr
 public :: MEF90DefMechSplit_SmoothPositiveSquare
 public :: MEF90DefMechSplit_DSmoothPositiveSquare
 public :: MEF90DefMechSplit_D2SmoothPositiveSquare
@@ -36,8 +41,8 @@ end type MEF90DefMechSplit
 abstract interface
 
    subroutine setupInterface(self, Strain, ierr)
-      use m_MEF90
-      import :: MEF90DefMechSplit
+      use, intrinsic :: iso_c_binding
+      import :: MEF90DefMechSplit, mef90Mat
       implicit none(type, external)
 
       class(MEF90DefMechSplit), intent(inout) :: self
@@ -46,8 +51,8 @@ abstract interface
    end subroutine setupInterface
 
    subroutine EEDInterface(self, HookesLaw, phi, EEDPlus, EEDMinus, ierr)
-      use m_MEF90
-      import :: MEF90DefMechSplit
+      use, intrinsic :: iso_c_binding
+      import :: MEF90DefMechSplit, mef90Mat, MEF90HookesLaw
       implicit none(type, external)
 
       class(MEF90DefMechSplit), intent(IN) :: self
@@ -58,8 +63,8 @@ abstract interface
    end subroutine EEDInterface
 
    subroutine DEEDInterface(self, HookesLaw, phi, DEEDPlus, DEEDMinus, ierr)
-      use m_MEF90
-      import :: MEF90DefMechSplit
+      use, intrinsic :: iso_c_binding
+      import :: MEF90DefMechSplit, mef90Mat, MEF90HookesLaw
       implicit none(type, external)
 
       class(MEF90DefMechSplit), intent(IN) :: self
@@ -70,8 +75,8 @@ abstract interface
    end subroutine DEEDInterface
 
    subroutine D2EEDInterface(self, HookesLaw, phi, psi, D2EEDPlus, D2EEDMinus, ierr)
-      use m_MEF90
-      import :: MEF90DefMechSplit
+      use, intrinsic :: iso_c_binding
+      import :: MEF90DefMechSplit, mef90Mat, MEF90HookesLaw
       implicit none(type, external)
 
       class(MEF90DefMechSplit), intent(IN) :: self

--- a/m_DefMech/m_MEF90_DefMechSplitDeviatoric.F90
+++ b/m_DefMech/m_MEF90_DefMechSplitDeviatoric.F90
@@ -1,7 +1,10 @@
 #include "../MEF90/mef90.inc"
 module m_MEF90_DefMechSplitDeviatoric
 #include "petsc/finclude/petsc.h"
+use petscsys
+use, intrinsic :: iso_c_binding
 use m_MEF90_DefMechSplit_class
+use m_MEF90_LinAlg
 use m_MEF90_Materials
 use m_MEF90_HookesLaw
 implicit none(type)

--- a/m_DefMech/m_MEF90_DefMechSplitHD.F90
+++ b/m_DefMech/m_MEF90_DefMechSplitHD.F90
@@ -1,7 +1,10 @@
 #include "../MEF90/mef90.inc"
 module m_MEF90_DefMechSplitHD
 #include "petsc/finclude/petsc.h"
+use petscsys
+use, intrinsic :: iso_c_binding
 use m_MEF90_DefMechSplit_class
+use m_MEF90_LinAlg
 use m_MEF90_Materials
 use m_MEF90_HookesLaw
 implicit none(type)

--- a/m_DefMech/m_MEF90_DefMechSplitNone.F90
+++ b/m_DefMech/m_MEF90_DefMechSplitNone.F90
@@ -1,6 +1,8 @@
 #include "../MEF90/mef90.inc"
 module m_MEF90_DefMechSplitNone
 #include "petsc/finclude/petsc.h"
+use petscsys
+use, intrinsic :: iso_c_binding
 use m_MEF90_DefMechSplit_class
 use m_MEF90_Materials
 use m_MEF90_HookesLaw

--- a/m_HeatXfer/Makefile
+++ b/m_HeatXfer/Makefile
@@ -21,19 +21,19 @@ m_HeatXfer:m_MEF90_HeatXfer.o
 
 m_MEF90_HeatXfer.o: ${BASE_DIR}/m_MEF90_HeatXfer.F90 m_MEF90_HeatXferCtx.o m_MEF90_HeatXferAssembly2D.o  m_MEF90_HeatXferAssembly3D.o 
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 m_MEF90_HeatXferAssembly2D.o: ${BASE_DIR}/m_MEF90_HeatXferAssembly.F90 m_MEF90_HeatXferCtx.o
 	@echo "      $< MEF90_DIM=2"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_DIM=2 -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_DIM=2 -c -o $@ $<
 
 m_MEF90_HeatXferAssembly3D.o: ${BASE_DIR}/m_MEF90_HeatXferAssembly.F90 m_MEF90_HeatXferCtx.o
 	@echo "      $< MEF90_DIM=3"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_DIM=3 -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -DMEF90_DIM=3 -c -o $@ $<
 
 m_MEF90_HeatXferCtx.o: ${BASE_DIR}/m_MEF90_HeatXferCtx.F90
 	@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 MEF90:
 	${MAKE} -C ${MEF90_DIR} MEF90

--- a/m_HeatXfer/m_MEF90_HeatXfer.F90
+++ b/m_HeatXfer/m_MEF90_HeatXfer.F90
@@ -3,6 +3,7 @@ module m_MEF90_HeatXfer
 #include "petsc/finclude/petsc.h"
    use petscsnes
    use petsctao
+   use petscts
    use m_MEF90_Parameters, only: Kr, Ki
    use m_MEF90_Ctx, only: MEF90CtxGlobalOptions_Type, PetscBagGetDataMEF90CtxGlobalOptions, &
                           MEF90Scaling_CST, MEF90Scaling_Expr, MEF90Scaling_File, MEF90Scaling_Linear

--- a/m_HeatXfer/m_MEF90_HeatXfer.F90
+++ b/m_HeatXfer/m_MEF90_HeatXfer.F90
@@ -3,15 +3,21 @@ module m_MEF90_HeatXfer
 #include "petsc/finclude/petsc.h"
    use petscsnes
    use petsctao
-   use m_MEF90_EXO
-   use m_MEF90_HeatXferCtx
-   use m_MEF90_HeatXferAssembly2D, &
+   use m_MEF90_Parameters, only: Kr, Ki
+   use m_MEF90_Ctx, only: MEF90CtxGlobalOptions_Type, PetscBagGetDataMEF90CtxGlobalOptions, &
+                          MEF90Scaling_CST, MEF90Scaling_Expr, MEF90Scaling_File, MEF90Scaling_Linear
+   use m_MEF90_DMPlex, only: MEF90VecCopySF, MEF90VecSetBCValuesFromOptions, MEF90VecSetBCValuesFromOptionsExpr, &
+                             MEF90VecSetValuesFromOptions, MEF90VecSetValuesFromOptionsExpr
+   use m_MEF90_EXO, only: MEF90EXOVecLoad, MEF90EXOVecView
+   use m_MEF90_HeatXferCtx, only: MEF90HeatXferCtx_Type, MEF90HeatXferGlobalOptions_Type, &
+                                  PetscBagGetDataMEF90HeatXferCtxGlobalOptions
+   use m_MEF90_HeatXferAssembly2D, only: &
       MEF90HeatXferEnergy2D => MEF90HeatXferEnergy, &
       MEF90HeatXferOperator2D => MEF90HeatXferOperator, &
       MEF90HeatXferBilinearForm2D => MEF90HeatXferBilinearForm, &
       MEF90HeatXferIFunction2D => MEF90HeatXferIFunction, &
       MEF90HeatXferIJacobian2D => MEF90HeatXferIJacobian
-   use m_MEF90_HeatXferAssembly3D, &
+   use m_MEF90_HeatXferAssembly3D, only: &
       MEF90HeatXferEnergy3D => MEF90HeatXFerEnergy, &
       MEF90HeatXferOperator3D => MEF90HeatXferOperator, &
       MEF90HeatXferBilinearForm3D => MEF90HeatXferBilinearForm, &

--- a/m_HeatXfer/m_MEF90_HeatXferAssembly.F90
+++ b/m_HeatXfer/m_MEF90_HeatXferAssembly.F90
@@ -3,7 +3,23 @@ module MEF90_APPEND(m_MEF90_HeatXferAssembly,MEF90_DIM)D
 #include "petsc/finclude/petsc.h"
 use petscsnes
 use petsctao
-use m_MEF90_HeatXferCtx
+use petscdmplex
+use m_MEF90_Parameters, only: Kr, Ki
+use m_MEF90_LinAlg, only: MEF90_VECT, MEF90_MAT, MEF90_MATS, &
+                          operator(*), operator(+), operator(-), operator(/), &
+                          operator(.DotP.), assignment(=)
+use m_MEF90_Elements, only: MEF90_ELEMENT_SCAL, MEF90ElementType, &
+                            MEF90ElementGetType, MEF90ElementGetTypeBoundary, &
+                            MEF90ElementCreate, MEF90ElementDestroy
+use m_MEF90_Utils, only: MEF90ISAllGatherMerge
+use m_MEF90_Ctx, only: MEF90CtxGlobalOptions_Type, PetscBagGetDataMEF90CtxGlobalOptions
+use m_MEF90_DMPlex, only: MEF90CellSetLabelName, MEF90FaceSetLabelName, MEF90VecGlobalToLocalConstraint
+use m_MEF90_Materials, only: MEF90_MATPROP, PetscBagGetDataMEF90MatProp
+use m_MEF90_HeatXferCtx, only: MEF90HeatXferCtx_Type, MEF90HeatXferGlobalOptions_Type, &
+                               MEF90HeatXferCellSetOptions_Type, MEF90HeatXferFaceSetOptions_Type, &
+                               PetscBagGetDataMEF90HeatXferCtxGlobalOptions, &
+                               PetscBagGetDataMEF90HeatXferCtxCellSetOptions, &
+                               PetscBagGetDataMEF90HeatXferCtxFaceSetOptions
 implicit none(type, external)
 
 private

--- a/m_HeatXfer/m_MEF90_HeatXferCtx.F90
+++ b/m_HeatXfer/m_MEF90_HeatXferCtx.F90
@@ -1,5 +1,9 @@
 module m_MEF90_HeatXferCtx_Type
 #include "petsc/finclude/petsc.h"
+   use petscsys
+   use petscdmplex
+   use petscbag
+   use, intrinsic :: iso_c_binding
    use m_MEF90_Ctx
    implicit none(type, external)
    private
@@ -171,8 +175,14 @@ end module m_MEF90HeatXferVertexSetOptions_Private
 
 module m_MEF90_HeatXferCtx
 #include "petsc/finclude/petsc.h"
+   use petscsys
+   use petscdmplex
+   use petscbag
+   use, intrinsic :: iso_c_binding
+   use m_MEF90_Parameters
    use m_MEF90_Ctx
    use m_MEF90_DMPlex
+   use m_MEF90_Utils, only: MEF90ISAllGatherMerge
    use m_MEF90_Materials
    use m_MEF90_HeatXferCtx_Type
    use m_MEF90HeatXferGlobalOptions_Private

--- a/vDef/Makefile
+++ b/vDef/Makefile
@@ -1,6 +1,6 @@
 NP=2 
 all:
-	-@${MAKE} -C ${MEF90_DIR} vDef
+	@${MAKE} -C ${MEF90_DIR} vDef
 test: test2D test3D
 test2D: ${MEF90_DIR}/${PETSC_ARCH}/bin/vDef
 	-@for OPTIONSFILE in test7.yaml test8.yaml; do \
@@ -22,62 +22,62 @@ BASE_DIR=${MEF90_DIR}/vDef
 
 m_vDefDefault.o: ${BASE_DIR}/m_vDefDefault.F90 ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 vDef:${MEF90_DIR}/${PETSC_ARCH}/bin/vDef
 	-@echo "      $@"
 
 ${MEF90_DIR}/${PETSC_ARCH}/bin/vDef: vDef.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	-@echo "      $@"
-	-@${FLINKER} -o $@ vDef.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB} 
+	@${FLINKER} -o $@ vDef.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB} 
 
 vDef.o: ${BASE_DIR}/vDef.F90 m_vDefDefault.o ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 vDefP:${MEF90_DIR}/${PETSC_ARCH}/bin/vDefP
 	-@echo "      $@"
 
 ${MEF90_DIR}/${PETSC_ARCH}/bin/vDefP: vDefP.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	-@echo "      $@"
-	-@${FLINKER} -o $@ vDefP.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB} 
+	@${FLINKER} -o $@ vDefP.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB} 
 
 vDefP.o: ${BASE_DIR}/vDefP.F90 m_vDefDefault.o ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 vDefHF:${MEF90_DIR}/${PETSC_ARCH}/bin/vDefHF
 	-@echo "      $@"
 
 ${MEF90_DIR}/${PETSC_ARCH}/bin/vDefHF: vDefHF.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	-@echo "      $@"
-	-@${FLINKER} -o $@ vDefHF.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB} 
+	@${FLINKER} -o $@ vDefHF.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB} 
 
 vDefHF.o: ${BASE_DIR}/vDefHF.F90 m_vDefDefault.o ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 vDefUpa:${MEF90_DIR}/${PETSC_ARCH}/bin/vDefUpa
 	-@echo "      $@"
 
 ${MEF90_DIR}/${PETSC_ARCH}/bin/vDefUpa: vDefUpa.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	-@echo "      $@"
-	-@${FLINKER} -o $@ vDefUpa.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB} 
+	@${FLINKER} -o $@ vDefUpa.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB} 
 
 vDefUpa.o: ${BASE_DIR}/vDefUpa.F90 m_vDefDefault.o ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 vDefBT:${MEF90_DIR}/${PETSC_ARCH}/bin/vDefBT
 	-@echo "      $@"
 
 ${MEF90_DIR}/${PETSC_ARCH}/bin/vDefBT: vDefBT.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	-@echo "      $@"
-	-@${FLINKER} -o $@ vDefBT.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB} 
+	@${FLINKER} -o $@ vDefBT.o m_vDefDefault.o ${MEF90_OBJS} ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS} ${PETSC_FORTRAN_LIB} ${PETSC_LIB} ${MEF90_EXTRA_LIB} ${SNLP_LIB} ${SNLP_FORTRAN_LIB} 
 
 vDefBT.o: ${BASE_DIR}/vDefBT.F90 m_vDefDefault.o ${MEF90_DEFMECH_OBJS} ${MEF90_HEATXFER_OBJS}
 	-@echo "      $<"
-	-@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
+	@${FC} ${FC_FLAGS} ${FCPPFLAGS} -I${MEF90_INCLUDE} -c -o $@ $<
 
 testvDef:
 	@echo ;echo "Testing vDef with $${PREFIX} $${OPTIONSFILE}"

--- a/vDef/m_vDefDefault.F90
+++ b/vDef/m_vDefDefault.F90
@@ -4,6 +4,7 @@ module m_vDefDefault
    use petsc
    use m_MEF90
    use m_MEF90_DefMechCtx
+   use m_MEF90_DefMechAT, only: MEF90DefMech_damageTypeAT1, MEF90DefMech_damageTypeAT1exp, MEF90DefMech_damageTypeAT2, MEF90DefMech_damageTypeKKL
    use m_MEF90_HeatXferCtx
    implicit none(type, external)
 

--- a/vDef/vDef.F90
+++ b/vDef/vDef.F90
@@ -3,11 +3,17 @@ program vDef
 #include "petsc/finclude/petsc.h"
 #include "petsc/finclude/petsctao.h"
    use m_MEF90
+   use m_MEF90_Ctx, only: MEF90Ctx_Type, MEF90CtxGlobalOptions_Type, MEF90CtxCreate, MEF90CtxDestroy, &
+                          MEF90CtxGetTime, PetscBagGetDataMEF90CtxGlobalOptions
+   use m_MEF90_DMPlex, only: MEF90CellSetLabelName, MEF90FaceSetLabelName, MEF90VertexSetLabelName
+   use m_MEF90_Parameters, only: MEF90MXSTRLEN, kr, ki
    use m_MEF90_DefMechCtx
    use m_MEF90_DefMech
    use m_MEF90_HeatXferCtx
    use m_MEF90_HeatXfer
    use m_vDefDefault
+   use m_MEF90_EXO, only: MEF90CtxOpenEXO, MEF90EXODMView, MEF90EXOVecLoad
+   use m_MEF90_Utils, only: MEF90ISAllGatherMerge, MEF90FilePrefix
    use petsc
    use petsctao
    implicit none(type)

--- a/vDef/vDefBT.F90
+++ b/vDef/vDefBT.F90
@@ -3,12 +3,18 @@ program vDef
 #include <finclude/petscdef.h>
    use petsc
    use m_MEF90
+   use m_MEF90_Ctx, only: MEF90Ctx_Type, MEF90CtxGlobalOptions_Type, MEF90CtxCreate, MEF90CtxDestroy, &
+                          MEF90CtxGetTime, PetscBagGetDataMEF90CtxGlobalOptions
+   use m_MEF90_DMPlex, only: MEF90CellSetLabelName, MEF90FaceSetLabelName, MEF90VertexSetLabelName
+   use m_MEF90_Parameters, only: MEF90MXSTRLEN, kr, ki
    !Use m_vDef
    use m_MEF90_DefMechCtx
    use m_MEF90_DefMech
    use m_MEF90_HeatXferCtx
    use m_MEF90_HeatXfer
    use m_vDefDefault
+   use m_MEF90_EXO, only: MEF90CtxOpenEXO
+   use m_MEF90_Utils, only: MEF90ISAllGatherMerge, MEF90FilePrefix
    implicit none(type, external)
 
    PetscErrorCode                                     :: ierr

--- a/vDef/vDefHF.F90
+++ b/vDef/vDefHF.F90
@@ -4,11 +4,17 @@ program vDefHF
 
    use petsc
    use m_MEF90
+   use m_MEF90_Ctx, only: MEF90Ctx_Type, MEF90CtxGlobalOptions_Type, MEF90CtxCreate, MEF90CtxDestroy, &
+                          MEF90CtxGetTime, PetscBagGetDataMEF90CtxGlobalOptions
+   use m_MEF90_DMPlex, only: MEF90CellSetLabelName, MEF90FaceSetLabelName, MEF90VertexSetLabelName
+   use m_MEF90_Parameters, only: MEF90MXSTRLEN, kr, ki
    use m_MEF90_DefMechCtx
    use m_MEF90_DefMech
    use m_MEF90_HeatXferCtx
    use m_MEF90_HeatXfer
    use m_vDefDefault
+   use m_MEF90_EXO, only: MEF90CtxOpenEXO
+   use m_MEF90_Utils, only: MEF90ISAllGatherMerge, MEF90FilePrefix
    implicit none(type, external)
 
    PetscErrorCode                                     :: ierr

--- a/vDef/vDefP.F90
+++ b/vDef/vDefP.F90
@@ -4,11 +4,17 @@ program CoupledPlasticityDamage
 
    use petsc
    use m_MEF90
+   use m_MEF90_Ctx, only: MEF90Ctx_Type, MEF90CtxGlobalOptions_Type, MEF90CtxCreate, MEF90CtxDestroy, &
+                          MEF90CtxGetTime, PetscBagGetDataMEF90CtxGlobalOptions
+   use m_MEF90_DMPlex, only: MEF90CellSetLabelName, MEF90FaceSetLabelName, MEF90VertexSetLabelName
+   use m_MEF90_Parameters, only: MEF90MXSTRLEN, kr, ki
    use m_MEF90_DefMechCtx
    use m_MEF90_DefMech
    use m_MEF90_HeatXferCtx
    use m_MEF90_HeatXfer
    use m_vDefDefault
+   use m_MEF90_EXO, only: MEF90CtxOpenEXO
+   use m_MEF90_Utils, only: MEF90ISAllGatherMerge, MEF90FilePrefix
    implicit none(type, external)
 
    PetscErrorCode                                     :: ierr

--- a/vDef/vDefUpa.F90
+++ b/vDef/vDefUpa.F90
@@ -4,11 +4,17 @@ program CoupledPlasticityDamage
 
    use petsc
    use m_MEF90
+   use m_MEF90_Ctx, only: MEF90Ctx_Type, MEF90CtxGlobalOptions_Type, MEF90CtxCreate, MEF90CtxDestroy, &
+                          MEF90CtxGetTime, PetscBagGetDataMEF90CtxGlobalOptions
+   use m_MEF90_DMPlex, only: MEF90CellSetLabelName, MEF90FaceSetLabelName, MEF90VertexSetLabelName
+   use m_MEF90_Parameters, only: MEF90MXSTRLEN, kr, ki
    use m_MEF90_DefMechCtx
    use m_MEF90_DefMech
    use m_MEF90_HeatXferCtx
    use m_MEF90_HeatXfer
    use m_vDefDefault
+   use m_MEF90_EXO, only: MEF90CtxOpenEXO
+   use m_MEF90_Utils, only: MEF90ISAllGatherMerge, MEF90FilePrefix
    implicit none(type, external)
 
    PetscErrorCode                                     :: ierr


### PR DESCRIPTION
## What

Replaces bare `use m_MEF90_*` statements with explicit `use ..., only:` lists in the most expensive translation units, enables the `private` default in `m_MEF90_DefMechAssembly`, and completes the work by adding `private` + explicit `public ::` lists to **all** `MEF90/*.F90` base modules.

**Compile-time wins measured (earlier commits):**
- `m_DefMech/m_MEF90_DefMech.F90` — **150 s → 11 s**
- `m_DefMech/m_MEF90_DefMechAssembly.F90` — **56 s → 22 s** per 2D/3D instantiation; `.mod` 701 KB → 90 KB
- `m_HeatXfer/m_MEF90_HeatXfer.F90` — **20 s → 10 s**
- `m_HeatXfer/m_MEF90_HeatXferAssembly.F90` — converted for consistency

**Follow-on (latest commit):** all `MEF90/*.F90` modules now have `private` + explicit `public ::` lists, completing the namespace restriction.

## Why

Nearly all build time was in gfortran's front end merging the PETSc namespace that every MEF90 module re-exports: each `.mod` is 550–850 KB because bare `use petscsnes`/`use petsctao` symbols are public by default. The merge cost is super-linear — an *empty* module using seven MEF90 modules compiles in 114 s; the same module with `only:` lists takes 0.35 s.

**Note:** shrinking a base module's `.mod` via `private` does NOT by itself speed up consumers (measured: Materials `.mod` 569 KB → 47 KB but compile time unchanged). The win comes from reducing the *number* of fat modules each consumer merges via `only:` lists, not from `.mod` size.

## Fallout fixes (symbols only reachable through accidental re-export)

Adding `private` to all base modules broke every downstream file that relied on transitive re-exports. All fixed with direct `use` statements:

- `MEF90/`: `m_MEF90_Ctx` adds `MEF90CtxCreate`, `MEF90CtxDestroy`, `MEF90ElementFamilyLagrange` to its public list; `m_MEF90_EXO` adds `exodusII.inc`; `m_MEF90_DefMechSplitClass` abstract interface bodies use `import ::` + `use, intrinsic :: iso_c_binding` instead of `use m_MEF90`
- `m_HeatXfer/m_MEF90_HeatXferCtx.F90`: direct `petscsys`/`petscdmplex`/`petscbag`/`iso_c_binding` imports
- `m_DefMech/`: `DefMechCtx` gets direct PETSc imports; `DefMechSplit{None,HD,Deviatoric}` get `petscsys`/`iso_c_binding`; `SplitHD`/`SplitDeviatoric` add `use m_MEF90_LinAlg` for `MatS2D`/`MatS3D`; `m_MEF90_DefMech` moves `MXSTLN` from the Parameters `only:` list to `#include "exodusII.inc"`
- Application drivers (`HeatXfer`, `ThermoElasticity`, `vDef` variants, `WorkControlled`, `Utils/gmsh2exo`): added direct `use m_MEF90_Ctx`, `m_MEF90_DMPlex`, `m_MEF90_Parameters`, `m_MEF90_EXO`, `m_MEF90_Utils`
- `ThermoElasticity/m_vDefDefault.F90`: synced stale constructor to current `MEF90DefMechCellSetOptions_Type` (removed deleted fields)

## Verification

Clean `-j8` build of `make DIRS` (MEF90, m_HeatXfer, HeatXfer, m_DefMech, ThermoElasticity, vDef, Utils) completes with no Fortran errors. All binaries link. No `-Wimplicit-procedure` warnings in the build output.

Pre-existing failures not introduced by this PR:
- `Utils/viewSets` and `Utils/viewDAG` — C utilities have no rule in the objs flow (noted in CLAUDE.md)
- `WorkControlled` — Makefile references old `${PETSC_ARCH}/conf/rules` path
- `ThermoElastoPlasticity` — uses `#include <finclude/petscdef.h>` (old header path)

Generated with [Claude Code](https://claude.com/claude-code)